### PR TITLE
Add record history and detail screens for mobile and web

### DIFF
--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '../contexts/AuthContext';
 import LoginScreen from '../screens/auth/LoginScreen';
 import RecordInputScreen from '../screens/records/RecordInputScreen';
 import RecordHistoryScreen from '../screens/records/RecordHistoryScreen';
+import RecordDetailScreen from '../screens/records/RecordDetailScreen';
 import ScheduleScreen from '../screens/schedule/ScheduleScreen';
 import ClientListScreen from '../screens/clients/ClientListScreen';
 import SettingsScreen from '../screens/settings/SettingsScreen';
@@ -21,14 +22,29 @@ export type RootStackParamList = {
 
 export type MainTabParamList = {
   RecordInput: undefined;
-  RecordHistory: undefined;
+  RecordHistoryStack: undefined;
   Schedule: undefined;
   ClientList: undefined;
   Settings: undefined;
 };
 
+export type RecordHistoryStackParamList = {
+  RecordHistory: undefined;
+  RecordDetail: { recordId: string };
+};
+
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
+const RecordHistoryStack = createNativeStackNavigator<RecordHistoryStackParamList>();
+
+function RecordHistoryNavigator() {
+  return (
+    <RecordHistoryStack.Navigator screenOptions={{ headerShown: false }}>
+      <RecordHistoryStack.Screen name="RecordHistory" component={RecordHistoryScreen} />
+      <RecordHistoryStack.Screen name="RecordDetail" component={RecordDetailScreen} />
+    </RecordHistoryStack.Navigator>
+  );
+}
 
 function MainTabs() {
   const theme = useTheme();
@@ -62,8 +78,8 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="RecordHistory"
-        component={RecordHistoryScreen}
+        name="RecordHistoryStack"
+        component={RecordHistoryNavigator}
         options={{
           tabBarLabel: '履歴',
           tabBarIcon: ({ color, size }) => (

--- a/mobile/src/screens/records/RecordDetailScreen.tsx
+++ b/mobile/src/screens/records/RecordDetailScreen.tsx
@@ -1,0 +1,475 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  Divider,
+  IconButton,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { dataConnect } from '../../lib/firebase';
+import { getVisitRecord, GetVisitRecordData } from '@sanwa-houkai-app/dataconnect';
+import { RecordStackParamList } from './RecordHistoryScreen';
+
+type VisitRecord = NonNullable<GetVisitRecordData['visitRecord']>;
+
+interface Service {
+  typeId: string;
+  typeName: string;
+  items: { id: string; name: string }[];
+}
+
+interface Vitals {
+  pulse?: number;
+  bloodPressureHigh?: number;
+  bloodPressureLow?: number;
+}
+
+type RouteProps = RouteProp<RecordStackParamList, 'RecordDetail'>;
+type NavigationProp = NativeStackNavigationProp<RecordStackParamList, 'RecordDetail'>;
+
+export default function RecordDetailScreen() {
+  const theme = useTheme();
+  const route = useRoute<RouteProps>();
+  const navigation = useNavigation<NavigationProp>();
+  const { recordId } = route.params;
+
+  const [record, setRecord] = useState<VisitRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchRecord = async () => {
+      try {
+        const result = await getVisitRecord(dataConnect, { id: recordId });
+        if (result.data.visitRecord) {
+          setRecord(result.data.visitRecord);
+        } else {
+          setError('記録が見つかりません');
+        }
+      } catch (err) {
+        console.error('Failed to load record:', err);
+        setError('記録の読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecord();
+  }, [recordId]);
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 (${weekdays[date.getDay()]})`;
+  };
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${start.slice(0, 5)} - ${end.slice(0, 5)}`;
+  };
+
+  const parseServices = (servicesData: unknown): Service[] => {
+    if (!servicesData) return [];
+    try {
+      if (typeof servicesData === 'string') {
+        return JSON.parse(servicesData);
+      }
+      return servicesData as Service[];
+    } catch {
+      return [];
+    }
+  };
+
+  const parseVitals = (vitalsData: unknown): Vitals | null => {
+    if (!vitalsData) return null;
+    try {
+      if (typeof vitalsData === 'string') {
+        return JSON.parse(vitalsData);
+      }
+      return vitalsData as Vitals;
+    } catch {
+      return null;
+    }
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !record) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.header}>
+          <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+          <Text variant="titleLarge" style={styles.headerTitle}>
+            記録詳細
+          </Text>
+          <View style={{ width: 48 }} />
+        </View>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error || '記録が見つかりません'}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const services = parseServices(record.services);
+  const vitals = parseVitals(record.vitals);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+        <Text variant="titleLarge" style={styles.headerTitle}>
+          記録詳細
+        </Text>
+        <View style={{ width: 48 }} />
+      </View>
+
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        {/* Basic Info */}
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <Text variant="titleLarge" style={styles.clientName}>
+              {record.client.name}
+            </Text>
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                訪問日
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {formatDate(record.visitDate)}
+              </Text>
+            </View>
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                時間
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {formatTimeRange(record.startTime, record.endTime)}
+              </Text>
+            </View>
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                担当
+              </Text>
+              <Chip icon="account" compact>
+                {record.staff.name}
+              </Chip>
+            </View>
+            {record.visitReason && (
+              <View style={styles.infoRow}>
+                <Text variant="bodyMedium" style={styles.label}>
+                  訪問理由
+                </Text>
+                <Text variant="bodyLarge" style={styles.value}>
+                  {record.visitReason.name}
+                </Text>
+              </View>
+            )}
+          </Card.Content>
+        </Card>
+
+        {/* Vitals */}
+        {vitals && (vitals.pulse || vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                バイタル
+              </Text>
+              <View style={styles.vitalsContainer}>
+                {vitals.pulse && (
+                  <View style={styles.vitalItem}>
+                    <Text variant="bodyMedium" style={styles.vitalLabel}>
+                      脈拍
+                    </Text>
+                    <Text variant="headlineSmall" style={styles.vitalValue}>
+                      {vitals.pulse}
+                    </Text>
+                    <Text variant="bodySmall" style={styles.vitalUnit}>
+                      bpm
+                    </Text>
+                  </View>
+                )}
+                {(vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+                  <View style={styles.vitalItem}>
+                    <Text variant="bodyMedium" style={styles.vitalLabel}>
+                      血圧
+                    </Text>
+                    <Text variant="headlineSmall" style={styles.vitalValue}>
+                      {vitals.bloodPressureHigh || '-'}/{vitals.bloodPressureLow || '-'}
+                    </Text>
+                    <Text variant="bodySmall" style={styles.vitalUnit}>
+                      mmHg
+                    </Text>
+                  </View>
+                )}
+              </View>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Services */}
+        {services.length > 0 && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                サービス内容
+              </Text>
+              {services.map((service, index) => (
+                <View key={service.typeId} style={styles.serviceSection}>
+                  <Text variant="labelLarge" style={styles.serviceTypeLabel}>
+                    {service.typeName}
+                  </Text>
+                  <View style={styles.chipContainer}>
+                    {service.items.map((item) => (
+                      <Chip
+                        key={item.id}
+                        style={styles.serviceChip}
+                        textStyle={styles.serviceChipText}
+                      >
+                        {item.name}
+                      </Chip>
+                    ))}
+                  </View>
+                  {index < services.length - 1 && <Divider style={styles.serviceDivider} />}
+                </View>
+              ))}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Notes */}
+        {record.notes && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                特記事項
+              </Text>
+              <Text variant="bodyMedium" style={styles.notesText}>
+                {record.notes}
+              </Text>
+              {record.aiGenerated && (
+                <Chip icon="robot" style={styles.aiChip} compact>
+                  AI生成
+                </Chip>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Satisfaction */}
+        {record.satisfaction && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                満足度
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {record.satisfaction}
+              </Text>
+              {record.satisfactionReason && (
+                <Text variant="bodyMedium" style={styles.reasonText}>
+                  {record.satisfactionReason}
+                </Text>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Condition Change */}
+        {record.conditionChange && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                状態の変化
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {record.conditionChange}
+              </Text>
+              {record.conditionChangeDetail && (
+                <Text variant="bodyMedium" style={styles.reasonText}>
+                  {record.conditionChangeDetail}
+                </Text>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Service Change */}
+        {record.serviceChangeNeeded && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                サービス変更の必要性
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {record.serviceChangeNeeded}
+              </Text>
+              {record.serviceChangeDetail && (
+                <Text variant="bodyMedium" style={styles.reasonText}>
+                  {record.serviceChangeDetail}
+                </Text>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Metadata */}
+        <View style={styles.metadata}>
+          <Text variant="bodySmall" style={styles.metadataText}>
+            作成: {new Date(record.createdAt).toLocaleString('ja-JP')}
+          </Text>
+          {record.updatedAt !== record.createdAt && (
+            <Text variant="bodySmall" style={styles.metadataText}>
+              更新: {new Date(record.updatedAt).toLocaleString('ja-JP')}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    backgroundColor: '#FFFFFF',
+  },
+  headerTitle: {
+    fontWeight: '600',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  card: {
+    marginBottom: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  clientName: {
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  label: {
+    width: 80,
+    color: '#757575',
+  },
+  value: {
+    flex: 1,
+    color: '#212121',
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  vitalsContainer: {
+    flexDirection: 'row',
+    gap: 24,
+  },
+  vitalItem: {
+    alignItems: 'center',
+    backgroundColor: '#F5F5F5',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 8,
+  },
+  vitalLabel: {
+    color: '#757575',
+    marginBottom: 4,
+  },
+  vitalValue: {
+    fontWeight: '600',
+    color: '#212121',
+  },
+  vitalUnit: {
+    color: '#9E9E9E',
+    marginTop: 2,
+  },
+  serviceSection: {
+    marginBottom: 8,
+  },
+  serviceTypeLabel: {
+    color: '#616161',
+    marginBottom: 8,
+  },
+  chipContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  serviceChip: {
+    backgroundColor: '#E3F2FD',
+  },
+  serviceChipText: {
+    fontSize: 13,
+  },
+  serviceDivider: {
+    marginTop: 12,
+    marginBottom: 8,
+  },
+  notesText: {
+    color: '#424242',
+    lineHeight: 22,
+  },
+  aiChip: {
+    alignSelf: 'flex-start',
+    marginTop: 12,
+    backgroundColor: '#F3E5F5',
+  },
+  reasonText: {
+    marginTop: 8,
+    color: '#616161',
+  },
+  metadata: {
+    marginTop: 8,
+    paddingHorizontal: 4,
+  },
+  metadataText: {
+    color: '#9E9E9E',
+    marginBottom: 4,
+  },
+});

--- a/mobile/src/screens/records/RecordHistoryScreen.tsx
+++ b/mobile/src/screens/records/RecordHistoryScreen.tsx
@@ -1,21 +1,286 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { Text, useTheme } from 'react-native-paper';
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, StyleSheet, FlatList, RefreshControl, TouchableOpacity } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  Searchbar,
+  IconButton,
+  Menu,
+  Divider,
+} from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useStaff } from '../../hooks/useStaff';
+import { dataConnect } from '../../lib/firebase';
+import {
+  listVisitRecordsByDateRange,
+  listClients,
+  ListVisitRecordsByDateRangeData,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+
+type VisitRecord = ListVisitRecordsByDateRangeData['visitRecords'][0];
+type Client = ListClientsData['clients'][0];
+
+interface Service {
+  typeId: string;
+  typeName: string;
+  items: { id: string; name: string }[];
+}
+
+export type RecordStackParamList = {
+  RecordHistory: undefined;
+  RecordDetail: { recordId: string };
+};
+
+type NavigationProp = NativeStackNavigationProp<RecordStackParamList, 'RecordHistory'>;
+
+const DAYS_TO_LOAD = 30;
 
 export default function RecordHistoryScreen() {
   const theme = useTheme();
+  const navigation = useNavigation<NavigationProp>();
+  const { facilityId, loading: staffLoading } = useStaff();
+
+  const [records, setRecords] = useState<VisitRecord[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter state
+  const [filterClientId, setFilterClientId] = useState<string | null>(null);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const formatDateForApi = (date: Date) => {
+    return date.toISOString().split('T')[0];
+  };
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const endDate = new Date();
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - DAYS_TO_LOAD);
+
+      const [recordsRes, clientsRes] = await Promise.all([
+        listVisitRecordsByDateRange(dataConnect, {
+          facilityId,
+          startDate: formatDateForApi(startDate),
+          endDate: formatDateForApi(endDate),
+        }),
+        listClients(dataConnect, { facilityId }),
+      ]);
+
+      setRecords(recordsRes.data.visitRecords);
+      setClients(clientsRes.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load records:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  const handleRecordPress = (record: VisitRecord) => {
+    navigation.navigate('RecordDetail', { recordId: record.id });
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} (${weekdays[date.getDay()]})`;
+  };
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${start.slice(0, 5)}-${end.slice(0, 5)}`;
+  };
+
+  const parseServices = (servicesData: unknown): Service[] => {
+    if (!servicesData) return [];
+    try {
+      if (typeof servicesData === 'string') {
+        return JSON.parse(servicesData);
+      }
+      return servicesData as Service[];
+    } catch {
+      return [];
+    }
+  };
+
+  const getServiceSummary = (record: VisitRecord): string => {
+    const services = parseServices(record.services);
+    if (services.length === 0) return '';
+
+    return services
+      .map((s) => {
+        const itemNames = s.items.map((i) => i.name).join('、');
+        return `${s.typeName}: ${itemNames}`;
+      })
+      .join(' / ');
+  };
+
+  const filteredRecords = filterClientId
+    ? records.filter((r) => r.client.id === filterClientId)
+    : records;
+
+  const selectedClientName = filterClientId
+    ? clients.find((c) => c.id === filterClientId)?.name || '不明'
+    : null;
+
+  const renderRecord = ({ item }: { item: VisitRecord }) => (
+    <TouchableOpacity onPress={() => handleRecordPress(item)} activeOpacity={0.7}>
+      <Card style={styles.card} mode="elevated">
+        <Card.Content>
+          <View style={styles.cardHeader}>
+            <Text variant="titleMedium" style={styles.dateText}>
+              {formatDate(item.visitDate)} {formatTimeRange(item.startTime, item.endTime)}
+            </Text>
+          </View>
+          <Text variant="titleLarge" style={styles.clientName}>
+            {item.client.name}
+          </Text>
+          <Text variant="bodyMedium" style={styles.serviceText} numberOfLines={2}>
+            {getServiceSummary(item)}
+          </Text>
+          <View style={styles.cardFooter}>
+            <Chip icon="account" compact textStyle={styles.chipText}>
+              {item.staff.name}
+            </Chip>
+          </View>
+        </Card.Content>
+      </Card>
+    </TouchableOpacity>
+  );
+
+  if (staffLoading || loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>スタッフ情報が見つかりません</Text>
+          <Text style={styles.subText}>管理者にお問い合わせください</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.content}>
-        <Text variant="headlineMedium" style={{ color: theme.colors.primary }}>
+      <View style={styles.header}>
+        <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.primary }]}>
           履歴
         </Text>
-        <Text variant="bodyMedium" style={styles.placeholder}>
-          訪問記録の履歴一覧（実装予定）
-        </Text>
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <IconButton
+              icon="filter-variant"
+              size={24}
+              onPress={() => setMenuVisible(true)}
+              style={filterClientId ? { backgroundColor: theme.colors.primaryContainer } : undefined}
+            />
+          }
+        >
+          <Menu.Item
+            onPress={() => {
+              setFilterClientId(null);
+              setMenuVisible(false);
+            }}
+            title="すべて表示"
+            leadingIcon={filterClientId === null ? 'check' : undefined}
+          />
+          <Divider />
+          {clients.map((client) => (
+            <Menu.Item
+              key={client.id}
+              onPress={() => {
+                setFilterClientId(client.id);
+                setMenuVisible(false);
+              }}
+              title={client.name}
+              leadingIcon={filterClientId === client.id ? 'check' : undefined}
+            />
+          ))}
+        </Menu>
       </View>
+
+      {filterClientId && (
+        <View style={styles.filterChipContainer}>
+          <Chip
+            icon="account"
+            onClose={() => setFilterClientId(null)}
+            style={styles.filterChip}
+          >
+            {selectedClientName}
+          </Chip>
+        </View>
+      )}
+
+      <FlatList
+        data={filteredRecords}
+        renderItem={renderRecord}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>
+              {filterClientId
+                ? 'この利用者の記録はありません'
+                : '記録がありません'}
+            </Text>
+            <Text style={styles.emptySubText}>
+              直近{DAYS_TO_LOAD}日間の記録を表示しています
+            </Text>
+          </View>
+        }
+      />
     </SafeAreaView>
   );
 }
@@ -25,14 +290,85 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#FAFAFA',
   },
-  content: {
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  title: {
+    fontWeight: '600',
+  },
+  filterChipContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  filterChip: {
+    alignSelf: 'flex-start',
+  },
+  loadingContainer: {
     flex: 1,
-    padding: 16,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  placeholder: {
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  subText: {
     marginTop: 8,
     color: '#757575',
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 8,
+  },
+  card: {
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  dateText: {
+    color: '#616161',
+  },
+  clientName: {
+    fontWeight: '600',
+    marginBottom: 8,
+  },
+  serviceText: {
+    color: '#757575',
+    marginBottom: 12,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#757575',
+  },
+  emptySubText: {
+    marginTop: 8,
+    fontSize: 14,
+    color: '#9E9E9E',
   },
 });

--- a/web/src/app/records/[id]/page.tsx
+++ b/web/src/app/records/[id]/page.tsx
@@ -1,0 +1,364 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Alert,
+  Button,
+  Grid,
+  Divider,
+  Paper,
+} from '@mui/material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Person as PersonIcon,
+  AccessTime as AccessTimeIcon,
+  CalendarToday as CalendarIcon,
+  SmartToy as AiIcon,
+} from '@mui/icons-material';
+import { MainLayout } from '@/components/layout';
+import { dataConnect } from '@/lib/firebase';
+import { getVisitRecord, GetVisitRecordData } from '@sanwa-houkai-app/dataconnect';
+
+type VisitRecord = NonNullable<GetVisitRecordData['visitRecord']>;
+
+interface Service {
+  typeId: string;
+  typeName: string;
+  items: { id: string; name: string }[];
+}
+
+interface Vitals {
+  pulse?: number;
+  bloodPressureHigh?: number;
+  bloodPressureLow?: number;
+}
+
+export default function RecordDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const recordId = params.id as string;
+
+  const [record, setRecord] = useState<VisitRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchRecord = async () => {
+      try {
+        const result = await getVisitRecord(dataConnect, { id: recordId });
+        if (result.data.visitRecord) {
+          setRecord(result.data.visitRecord);
+        } else {
+          setError('記録が見つかりません');
+        }
+      } catch (err) {
+        console.error('Failed to load record:', err);
+        setError('記録の読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchRecord();
+  }, [recordId]);
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 (${weekdays[date.getDay()]})`;
+  };
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${start.slice(0, 5)} - ${end.slice(0, 5)}`;
+  };
+
+  const parseServices = (servicesData: unknown): Service[] => {
+    if (!servicesData) return [];
+    try {
+      if (typeof servicesData === 'string') {
+        return JSON.parse(servicesData);
+      }
+      return servicesData as Service[];
+    } catch {
+      return [];
+    }
+  };
+
+  const parseVitals = (vitalsData: unknown): Vitals | null => {
+    if (!vitalsData) return null;
+    try {
+      if (typeof vitalsData === 'string') {
+        return JSON.parse(vitalsData);
+      }
+      return vitalsData as Vitals;
+    } catch {
+      return null;
+    }
+  };
+
+  if (loading) {
+    return (
+      <MainLayout title="記録詳細">
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  if (error || !record) {
+    return (
+      <MainLayout title="記録詳細">
+        <Box mb={2}>
+          <Button
+            startIcon={<ArrowBackIcon />}
+            onClick={() => router.push('/records')}
+          >
+            一覧に戻る
+          </Button>
+        </Box>
+        <Alert severity="error">{error || '記録が見つかりません'}</Alert>
+      </MainLayout>
+    );
+  }
+
+  const services = parseServices(record.services);
+  const vitals = parseVitals(record.vitals);
+
+  return (
+    <MainLayout title="記録詳細">
+      <Box mb={3}>
+        <Button
+          startIcon={<ArrowBackIcon />}
+          onClick={() => router.push('/records')}
+        >
+          一覧に戻る
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {/* Basic Info */}
+        <Grid size={12}>
+          <Card>
+            <CardContent>
+              <Typography variant="h5" fontWeight={600} gutterBottom>
+                {record.client.name}
+              </Typography>
+              <Box display="flex" flexWrap="wrap" gap={3} mt={2}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <CalendarIcon color="action" />
+                  <Typography>{formatDate(record.visitDate)}</Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <AccessTimeIcon color="action" />
+                  <Typography>{formatTimeRange(record.startTime, record.endTime)}</Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <PersonIcon color="action" />
+                  <Chip label={record.staff.name} variant="outlined" />
+                </Box>
+                {record.visitReason && (
+                  <Chip label={record.visitReason.name} color="primary" variant="outlined" />
+                )}
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Vitals */}
+        {vitals && (vitals.pulse || vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  バイタル
+                </Typography>
+                <Box display="flex" gap={3} flexWrap="wrap">
+                  {vitals.pulse && (
+                    <Paper
+                      variant="outlined"
+                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        脈拍
+                      </Typography>
+                      <Typography variant="h5" fontWeight={600}>
+                        {vitals.pulse}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        bpm
+                      </Typography>
+                    </Paper>
+                  )}
+                  {(vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+                    <Paper
+                      variant="outlined"
+                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        血圧
+                      </Typography>
+                      <Typography variant="h5" fontWeight={600}>
+                        {vitals.bloodPressureHigh || '-'}/{vitals.bloodPressureLow || '-'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        mmHg
+                      </Typography>
+                    </Paper>
+                  )}
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Services */}
+        {services.length > 0 && (
+          <Grid size={{ xs: 12, md: vitals ? 8 : 12 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  サービス内容
+                </Typography>
+                {services.map((service, index) => (
+                  <Box key={service.typeId} mb={index < services.length - 1 ? 2 : 0}>
+                    <Typography
+                      variant="subtitle2"
+                      color="text.secondary"
+                      gutterBottom
+                    >
+                      {service.typeName}
+                    </Typography>
+                    <Box display="flex" flexWrap="wrap" gap={1}>
+                      {service.items.map((item) => (
+                        <Chip
+                          key={item.id}
+                          label={item.name}
+                          size="small"
+                          sx={{ bgcolor: 'primary.50' }}
+                        />
+                      ))}
+                    </Box>
+                    {index < services.length - 1 && <Divider sx={{ mt: 2 }} />}
+                  </Box>
+                ))}
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Notes */}
+        {record.notes && (
+          <Grid size={12}>
+            <Card>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <Typography variant="h6">特記事項</Typography>
+                  {record.aiGenerated && (
+                    <Chip
+                      icon={<AiIcon />}
+                      label="AI生成"
+                      size="small"
+                      color="secondary"
+                      variant="outlined"
+                    />
+                  )}
+                </Box>
+                <Typography
+                  variant="body1"
+                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
+                >
+                  {record.notes}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Satisfaction */}
+        {record.satisfaction && (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  満足度
+                </Typography>
+                <Typography variant="body1" fontWeight={500}>
+                  {record.satisfaction}
+                </Typography>
+                {record.satisfactionReason && (
+                  <Typography variant="body2" color="text.secondary" mt={1}>
+                    {record.satisfactionReason}
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Condition Change */}
+        {record.conditionChange && (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  状態の変化
+                </Typography>
+                <Typography variant="body1" fontWeight={500}>
+                  {record.conditionChange}
+                </Typography>
+                {record.conditionChangeDetail && (
+                  <Typography variant="body2" color="text.secondary" mt={1}>
+                    {record.conditionChangeDetail}
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Service Change */}
+        {record.serviceChangeNeeded && (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  サービス変更の必要性
+                </Typography>
+                <Typography variant="body1" fontWeight={500}>
+                  {record.serviceChangeNeeded}
+                </Typography>
+                {record.serviceChangeDetail && (
+                  <Typography variant="body2" color="text.secondary" mt={1}>
+                    {record.serviceChangeDetail}
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Metadata */}
+        <Grid size={12}>
+          <Box display="flex" justifyContent="flex-end" gap={3}>
+            <Typography variant="caption" color="text.secondary">
+              作成: {new Date(record.createdAt).toLocaleString('ja-JP')}
+            </Typography>
+            {record.updatedAt !== record.createdAt && (
+              <Typography variant="caption" color="text.secondary">
+                更新: {new Date(record.updatedAt).toLocaleString('ja-JP')}
+              </Typography>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+    </MainLayout>
+  );
+}

--- a/web/src/app/records/page.tsx
+++ b/web/src/app/records/page.tsx
@@ -1,21 +1,327 @@
 'use client';
 
-import { Box, Typography, Card, CardContent } from '@mui/material';
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  IconButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Alert,
+  Tooltip,
+  TablePagination,
+} from '@mui/material';
+import {
+  Visibility as VisibilityIcon,
+  Refresh as RefreshIcon,
+} from '@mui/icons-material';
+import { useRouter } from 'next/navigation';
 import { MainLayout } from '@/components/layout';
+import { useStaff } from '@/hooks/useStaff';
+import { dataConnect } from '@/lib/firebase';
+import {
+  listVisitRecordsByDateRange,
+  listClients,
+  ListVisitRecordsByDateRangeData,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+
+type VisitRecord = ListVisitRecordsByDateRangeData['visitRecords'][0];
+type Client = ListClientsData['clients'][0];
+
+interface Service {
+  typeId: string;
+  typeName: string;
+  items: { id: string; name: string }[];
+}
+
+const DAYS_TO_LOAD = 30;
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 export default function RecordsPage() {
+  const router = useRouter();
+  const { facilityId, loading: staffLoading } = useStaff();
+
+  const [records, setRecords] = useState<VisitRecord[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter & pagination state
+  const [filterClientId, setFilterClientId] = useState<string>('');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const formatDateForApi = (date: Date) => {
+    return date.toISOString().split('T')[0];
+  };
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const endDate = new Date();
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - DAYS_TO_LOAD);
+
+      const [recordsRes, clientsRes] = await Promise.all([
+        listVisitRecordsByDateRange(dataConnect, {
+          facilityId,
+          startDate: formatDateForApi(startDate),
+          endDate: formatDateForApi(endDate),
+        }),
+        listClients(dataConnect, { facilityId }),
+      ]);
+
+      setRecords(recordsRes.data.visitRecords);
+      setClients(clientsRes.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load records:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setLoading(true);
+    await fetchData();
+    setLoading(false);
+  };
+
+  const handleViewDetail = (recordId: string) => {
+    router.push(`/records/${recordId}`);
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')} (${weekdays[date.getDay()]})`;
+  };
+
+  const formatTimeRange = (start: string, end: string) => {
+    return `${start.slice(0, 5)}-${end.slice(0, 5)}`;
+  };
+
+  const parseServices = (servicesData: unknown): Service[] => {
+    if (!servicesData) return [];
+    try {
+      if (typeof servicesData === 'string') {
+        return JSON.parse(servicesData);
+      }
+      return servicesData as Service[];
+    } catch {
+      return [];
+    }
+  };
+
+  const getServiceSummary = (record: VisitRecord): string => {
+    const services = parseServices(record.services);
+    if (services.length === 0) return '-';
+
+    return services
+      .map((s) => {
+        const itemNames = s.items.map((i) => i.name).slice(0, 3).join('、');
+        const hasMore = s.items.length > 3;
+        return `${s.typeName}: ${itemNames}${hasMore ? '...' : ''}`;
+      })
+      .join(' / ');
+  };
+
+  const filteredRecords = filterClientId
+    ? records.filter((r) => r.client.id === filterClientId)
+    : records;
+
+  const paginatedRecords = filteredRecords.slice(
+    page * rowsPerPage,
+    page * rowsPerPage + rowsPerPage
+  );
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  if (staffLoading || loading) {
+    return (
+      <MainLayout title="履歴一覧">
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <MainLayout title="履歴一覧">
+        <Alert severity="error">
+          スタッフ情報が見つかりません。管理者にお問い合わせください。
+        </Alert>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout title="履歴一覧">
+        <Alert severity="error">{error}</Alert>
+      </MainLayout>
+    );
+  }
+
   return (
     <MainLayout title="履歴一覧">
       <Box>
-        <Card>
-          <CardContent sx={{ textAlign: 'center', py: 8 }}>
-            <Typography variant="h6" color="text.secondary">
-              履歴一覧画面
-            </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-              訪問介護記録の一覧を表示します（実装予定）
-            </Typography>
+        {/* Filters */}
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+              <FormControl size="small" sx={{ minWidth: 200 }}>
+                <InputLabel>利用者で絞り込み</InputLabel>
+                <Select
+                  value={filterClientId}
+                  label="利用者で絞り込み"
+                  onChange={(e) => {
+                    setFilterClientId(e.target.value);
+                    setPage(0);
+                  }}
+                >
+                  <MenuItem value="">すべて表示</MenuItem>
+                  {clients.map((client) => (
+                    <MenuItem key={client.id} value={client.id}>
+                      {client.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Tooltip title="更新">
+                <IconButton onClick={handleRefresh} color="primary">
+                  <RefreshIcon />
+                </IconButton>
+              </Tooltip>
+              <Typography variant="body2" color="text.secondary" sx={{ ml: 'auto' }}>
+                直近{DAYS_TO_LOAD}日間の記録を表示
+              </Typography>
+            </Box>
           </CardContent>
+        </Card>
+
+        {/* Records Table */}
+        <Card>
+          <TableContainer component={Paper} elevation={0}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>訪問日</TableCell>
+                  <TableCell>時間</TableCell>
+                  <TableCell>利用者</TableCell>
+                  <TableCell>サービス内容</TableCell>
+                  <TableCell>担当</TableCell>
+                  <TableCell align="center">操作</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {paginatedRecords.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center" sx={{ py: 8 }}>
+                      <Typography color="text.secondary">
+                        {filterClientId
+                          ? 'この利用者の記録はありません'
+                          : '記録がありません'}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  paginatedRecords.map((record) => (
+                    <TableRow
+                      key={record.id}
+                      hover
+                      sx={{ cursor: 'pointer' }}
+                      onClick={() => handleViewDetail(record.id)}
+                    >
+                      <TableCell>{formatDate(record.visitDate)}</TableCell>
+                      <TableCell>{formatTimeRange(record.startTime, record.endTime)}</TableCell>
+                      <TableCell>
+                        <Typography fontWeight={500}>{record.client.name}</Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography
+                          variant="body2"
+                          color="text.secondary"
+                          sx={{
+                            maxWidth: 300,
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {getServiceSummary(record)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Chip label={record.staff.name} size="small" variant="outlined" />
+                      </TableCell>
+                      <TableCell align="center">
+                        <Tooltip title="詳細を表示">
+                          <IconButton
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleViewDetail(record.id);
+                            }}
+                          >
+                            <VisibilityIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            component="div"
+            count={filteredRecords.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+            labelRowsPerPage="表示件数:"
+            labelDisplayedRows={({ from, to, count }) =>
+              `${from}-${to} / ${count}件`
+            }
+          />
         </Card>
       </Box>
     </MainLayout>


### PR DESCRIPTION
## Summary
- 履歴一覧画面と詳細画面をモバイル/Web両対応で実装
- Data Connect API経由で直近30日の訪問記録を取得・表示
- 利用者フィルター、ページネーション、プルリフレッシュに対応

## Changes

### Mobile
- `RecordHistoryScreen.tsx`: FlatListでカード形式の一覧表示、利用者フィルター、プルリフレッシュ
- `RecordDetailScreen.tsx`: バイタル、サービス内容、特記事項などの詳細表示
- `RootNavigator.tsx`: 履歴タブにスタックナビゲーション追加

### Web
- `records/page.tsx`: MUI Tableでテーブル形式の一覧表示、ページネーション、利用者フィルター
- `records/[id]/page.tsx`: Gridレイアウトで詳細表示

## Test plan
- [ ] モバイルアプリで履歴タブを開き、記録一覧が表示されることを確認
- [ ] モバイルアプリで記録カードをタップし、詳細画面に遷移することを確認
- [ ] Web管理画面で履歴一覧ページを開き、テーブル表示を確認
- [ ] Web管理画面で行クリックまたは詳細ボタンで詳細ページに遷移することを確認
- [ ] 利用者フィルターが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)