### PR TITLE
Add Firebase Hosting deployment setup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies (web)
+        working-directory: web
+        run: npm ci
+
+      - name: Build web app
+        working-directory: web
+        run: npm run build
+        env:
+          NEXT_PUBLIC_FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          NEXT_PUBLIC_FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          NEXT_PUBLIC_FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: sanwa-houkai-app

--- a/firebase.json
+++ b/firebase.json
@@ -1,4 +1,29 @@
 {
+  "hosting": {
+    "public": "web/out",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "**/*.@(js|css)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
+    ]
+  },
   "dataconnect": {
     "source": "dataconnect"
   }

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
+  trailingSlash: true,
 };
 
 export default nextConfig;

--- a/web/src/app/records/page.tsx
+++ b/web/src/app/records/page.tsx
@@ -114,7 +114,7 @@ export default function RecordsPage() {
   };
 
   const handleViewDetail = (recordId: string) => {
-    router.push(`/records/${recordId}`);
+    router.push(`/records/detail/?id=${recordId}`);
   };
 
   const formatDate = (dateStr: string) => {

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -1,7 +1,7 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getDataConnect } from 'firebase/data-connect';
+import { initializeApp, getApps, FirebaseApp } from 'firebase/app';
+import { getAuth, Auth } from 'firebase/auth';
+import { getFirestore, Firestore } from 'firebase/firestore';
+import { getDataConnect, DataConnect } from 'firebase/data-connect';
 import { connectorConfig } from '@sanwa-houkai-app/dataconnect';
 
 const firebaseConfig = {
@@ -13,12 +13,49 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Initialize Firebase
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
-const auth = getAuth(app);
-const db = getFirestore(app);
+// Skip initialization during build time when API key is not available
+const isValidConfig = firebaseConfig.apiKey && firebaseConfig.projectId;
 
-// Initialize Data Connect
-const dataConnect = getDataConnect(app, connectorConfig);
+let _app: FirebaseApp | null = null;
+let _auth: Auth | null = null;
+let _db: Firestore | null = null;
+let _dataConnect: DataConnect | null = null;
 
-export { app, auth, db, dataConnect };
+if (isValidConfig) {
+  // Initialize Firebase
+  _app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+  _auth = getAuth(_app);
+  _db = getFirestore(_app);
+
+  // Initialize Data Connect
+  _dataConnect = getDataConnect(_app, connectorConfig);
+}
+
+// Runtime getters that throw if Firebase is not initialized
+function getFirebaseApp(): FirebaseApp {
+  if (!_app) throw new Error('Firebase is not initialized. Check environment variables.');
+  return _app;
+}
+
+function getFirebaseAuth(): Auth {
+  if (!_auth) throw new Error('Firebase Auth is not initialized. Check environment variables.');
+  return _auth;
+}
+
+function getFirebaseDb(): Firestore {
+  if (!_db) throw new Error('Firestore is not initialized. Check environment variables.');
+  return _db;
+}
+
+function getFirebaseDataConnect(): DataConnect {
+  if (!_dataConnect) throw new Error('Data Connect is not initialized. Check environment variables.');
+  return _dataConnect;
+}
+
+// Export both direct references (nullable) and getter functions (non-nullable at runtime)
+export const app = _app as FirebaseApp;
+export const auth = _auth as Auth;
+export const db = _db as Firestore;
+export const dataConnect = _dataConnect as DataConnect;
+
+export { getFirebaseApp, getFirebaseAuth, getFirebaseDb, getFirebaseDataConnect };


### PR DESCRIPTION
## Summary
- Firebase Hostingの設定を追加（firebase.json）
- mainブランチへのpush時に自動デプロイするGitHub Actionsワークフローを追加
- Next.jsを静的エクスポートモードに設定
- 動的ルート `/records/[id]` をクエリパラメータ形式 `/records/detail?id=` に変換
- ビルド時のFirebase初期化エラーを修正

## Required Setup
PRマージ後、GitHub Secretsに以下を設定してください:
- `FIREBASE_API_KEY`
- `FIREBASE_AUTH_DOMAIN`
- `FIREBASE_PROJECT_ID`
- `FIREBASE_STORAGE_BUCKET`
- `FIREBASE_MESSAGING_SENDER_ID`
- `FIREBASE_APP_ID`
- `FIREBASE_SERVICE_ACCOUNT` (Firebase Hosting用サービスアカウントJSON)

## Test plan
- [x] ローカルでビルド成功確認
- [ ] GitHub Secrets設定後、mainへのpushでデプロイ実行確認
- [ ] Firebase Hosting URLでアプリ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)