### PR TITLE
Add client list and detail screens for mobile

### DIFF
--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -13,6 +13,7 @@ import RecordHistoryScreen from '../screens/records/RecordHistoryScreen';
 import RecordDetailScreen from '../screens/records/RecordDetailScreen';
 import ScheduleScreen from '../screens/schedule/ScheduleScreen';
 import ClientListScreen from '../screens/clients/ClientListScreen';
+import ClientDetailScreen from '../screens/clients/ClientDetailScreen';
 import SettingsScreen from '../screens/settings/SettingsScreen';
 
 export type RootStackParamList = {
@@ -24,7 +25,7 @@ export type MainTabParamList = {
   RecordInput: undefined;
   RecordHistoryStack: undefined;
   Schedule: undefined;
-  ClientList: undefined;
+  ClientStack: undefined;
   Settings: undefined;
 };
 
@@ -33,9 +34,15 @@ export type RecordHistoryStackParamList = {
   RecordDetail: { recordId: string };
 };
 
+export type ClientStackParamList = {
+  ClientList: undefined;
+  ClientDetail: { clientId: string };
+};
+
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
 const RecordHistoryStack = createNativeStackNavigator<RecordHistoryStackParamList>();
+const ClientStack = createNativeStackNavigator<ClientStackParamList>();
 
 function RecordHistoryNavigator() {
   return (
@@ -43,6 +50,15 @@ function RecordHistoryNavigator() {
       <RecordHistoryStack.Screen name="RecordHistory" component={RecordHistoryScreen} />
       <RecordHistoryStack.Screen name="RecordDetail" component={RecordDetailScreen} />
     </RecordHistoryStack.Navigator>
+  );
+}
+
+function ClientNavigator() {
+  return (
+    <ClientStack.Navigator screenOptions={{ headerShown: false }}>
+      <ClientStack.Screen name="ClientList" component={ClientListScreen} />
+      <ClientStack.Screen name="ClientDetail" component={ClientDetailScreen} />
+    </ClientStack.Navigator>
   );
 }
 
@@ -98,8 +114,8 @@ function MainTabs() {
         }}
       />
       <Tab.Screen
-        name="ClientList"
-        component={ClientListScreen}
+        name="ClientStack"
+        component={ClientNavigator}
         options={{
           tabBarLabel: '利用者',
           tabBarIcon: ({ color, size }) => (

--- a/mobile/src/screens/clients/ClientDetailScreen.tsx
+++ b/mobile/src/screens/clients/ClientDetailScreen.tsx
@@ -1,0 +1,511 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, ScrollView, Linking, Alert } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  IconButton,
+  Button,
+  Divider,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { dataConnect } from '../../lib/firebase';
+import { getClient, GetClientData } from '@sanwa-houkai-app/dataconnect';
+import { ClientStackParamList } from '../../navigation/RootNavigator';
+
+type Client = NonNullable<GetClientData['client']>;
+
+type RouteProps = RouteProp<ClientStackParamList, 'ClientDetail'>;
+type NavigationProp = NativeStackNavigationProp<ClientStackParamList, 'ClientDetail'>;
+
+export default function ClientDetailScreen() {
+  const theme = useTheme();
+  const route = useRoute<RouteProps>();
+  const navigation = useNavigation<NavigationProp>();
+  const { clientId } = route.params;
+
+  const [client, setClient] = useState<Client | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchClient = async () => {
+      try {
+        const result = await getClient(dataConnect, { id: clientId });
+        if (result.data.client) {
+          setClient(result.data.client);
+        } else {
+          setError('利用者が見つかりません');
+        }
+      } catch (err) {
+        console.error('Failed to load client:', err);
+        setError('利用者情報の読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchClient();
+  }, [clientId]);
+
+  const handlePhonePress = (phone: string | null | undefined, label: string) => {
+    if (!phone) {
+      Alert.alert('電話番号なし', `${label}の電話番号は登録されていません`);
+      return;
+    }
+
+    Alert.alert(
+      '電話をかける',
+      `${phone} に電話をかけますか？`,
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        { text: '電話する', onPress: () => Linking.openURL(`tel:${phone}`) },
+      ]
+    );
+  };
+
+  const formatDate = (dateStr: string | null | undefined) => {
+    if (!dateStr) return '-';
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+  };
+
+  const calculateAge = (birthDate: string | null | undefined): string => {
+    if (!birthDate) return '-';
+    const birth = new Date(birthDate);
+    const today = new Date();
+    let age = today.getFullYear() - birth.getFullYear();
+    const monthDiff = today.getMonth() - birth.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+      age--;
+    }
+    return `${age}歳`;
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !client) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.header}>
+          <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+          <Text variant="titleLarge" style={styles.headerTitle}>
+            利用者詳細
+          </Text>
+          <View style={{ width: 48 }} />
+        </View>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error || '利用者が見つかりません'}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+        <Text variant="titleLarge" style={styles.headerTitle}>
+          利用者詳細
+        </Text>
+        <View style={{ width: 48 }} />
+      </View>
+
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        {/* Basic Info */}
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <View style={styles.nameSection}>
+              <View style={styles.nameContainer}>
+                <Text variant="headlineSmall" style={styles.clientName}>
+                  {client.name}
+                </Text>
+                {client.nameKana && (
+                  <Text variant="bodyMedium" style={styles.nameKana}>
+                    {client.nameKana}
+                  </Text>
+                )}
+              </View>
+              {!client.isActive && (
+                <Chip style={styles.inactiveChip} textStyle={styles.inactiveChipText}>
+                  非アクティブ
+                </Chip>
+              )}
+            </View>
+
+            <View style={styles.chipRow}>
+              {client.careLevel?.name && (
+                <Chip
+                  style={[styles.careLevelChip, { backgroundColor: theme.colors.secondaryContainer }]}
+                  textStyle={styles.chipText}
+                >
+                  {client.careLevel.name}
+                </Chip>
+              )}
+              {client.gender && (
+                <Chip style={styles.genderChip} textStyle={styles.chipText}>
+                  {client.gender}
+                </Chip>
+              )}
+              {client.birthDate && (
+                <Chip style={styles.ageChip} textStyle={styles.chipText}>
+                  {calculateAge(client.birthDate)}
+                </Chip>
+              )}
+            </View>
+
+            {client.birthDate && (
+              <View style={styles.infoRow}>
+                <Text variant="bodyMedium" style={styles.label}>
+                  生年月日
+                </Text>
+                <Text variant="bodyLarge" style={styles.value}>
+                  {formatDate(client.birthDate)}
+                </Text>
+              </View>
+            )}
+          </Card.Content>
+        </Card>
+
+        {/* Contact Info */}
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <Text variant="titleMedium" style={styles.sectionTitle}>
+              連絡先
+            </Text>
+
+            {(client.addressPrefecture || client.addressCity) && (
+              <View style={styles.infoRow}>
+                <Text variant="bodyMedium" style={styles.label}>
+                  住所
+                </Text>
+                <Text variant="bodyLarge" style={styles.value}>
+                  {[client.addressPrefecture, client.addressCity].filter(Boolean).join(' ')}
+                </Text>
+              </View>
+            )}
+
+            <View style={styles.phoneRow}>
+              <View style={styles.phoneInfo}>
+                <Text variant="bodyMedium" style={styles.label}>
+                  電話番号
+                </Text>
+                <Text variant="bodyLarge" style={styles.value}>
+                  {client.phone || '-'}
+                </Text>
+              </View>
+              <Button
+                mode="outlined"
+                icon="phone"
+                onPress={() => handlePhonePress(client.phone, '利用者')}
+                disabled={!client.phone}
+                compact
+              >
+                発信
+              </Button>
+            </View>
+          </Card.Content>
+        </Card>
+
+        {/* Emergency Contact */}
+        {(client.emergencyName || client.emergencyPhone) && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                緊急連絡先
+              </Text>
+
+              {client.emergencyName && (
+                <View style={styles.infoRow}>
+                  <Text variant="bodyMedium" style={styles.label}>
+                    氏名
+                  </Text>
+                  <Text variant="bodyLarge" style={styles.value}>
+                    {client.emergencyName}
+                    {client.emergencyRelation && ` (${client.emergencyRelation})`}
+                  </Text>
+                </View>
+              )}
+
+              <View style={styles.phoneRow}>
+                <View style={styles.phoneInfo}>
+                  <Text variant="bodyMedium" style={styles.label}>
+                    電話番号
+                  </Text>
+                  <Text variant="bodyLarge" style={styles.value}>
+                    {client.emergencyPhone || '-'}
+                  </Text>
+                </View>
+                <Button
+                  mode="outlined"
+                  icon="phone"
+                  onPress={() => handlePhonePress(client.emergencyPhone, '緊急連絡先')}
+                  disabled={!client.emergencyPhone}
+                  compact
+                  buttonColor="#FFF3E0"
+                >
+                  発信
+                </Button>
+              </View>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Care Info */}
+        {(client.careManager || client.careOffice) && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                ケア情報
+              </Text>
+
+              {client.careManager && (
+                <View style={styles.infoRow}>
+                  <Text variant="bodyMedium" style={styles.label}>
+                    ケアマネ
+                  </Text>
+                  <Text variant="bodyLarge" style={styles.value}>
+                    {client.careManager}
+                  </Text>
+                </View>
+              )}
+
+              {client.careOffice && (
+                <View style={styles.infoRow}>
+                  <Text variant="bodyMedium" style={styles.label}>
+                    事業所
+                  </Text>
+                  <Text variant="bodyLarge" style={styles.value}>
+                    {client.careOffice}
+                  </Text>
+                </View>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Assessment */}
+        {(!!client.assessment || client.lastAssessmentDate) && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                アセスメント
+              </Text>
+
+              {client.lastAssessmentDate && (
+                <View style={styles.infoRow}>
+                  <Text variant="bodyMedium" style={styles.label}>
+                    最終評価日
+                  </Text>
+                  <Text variant="bodyLarge" style={styles.value}>
+                    {formatDate(client.lastAssessmentDate)}
+                  </Text>
+                </View>
+              )}
+
+              {!!client.assessment && (
+                <>
+                  <Divider style={styles.divider} />
+                  <Text variant="bodyMedium" style={styles.assessmentText}>
+                    {typeof client.assessment === 'string' ? client.assessment : JSON.stringify(client.assessment)}
+                  </Text>
+                </>
+              )}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Regular Services */}
+        {!!client.regularServices && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                定期サービス
+              </Text>
+              <Text variant="bodyMedium" style={styles.servicesText}>
+                {typeof client.regularServices === 'string' ? client.regularServices : JSON.stringify(client.regularServices)}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Notes */}
+        {client.notes && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                備考
+              </Text>
+              <Text variant="bodyMedium" style={styles.notesText}>
+                {client.notes}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Metadata */}
+        <View style={styles.metadata}>
+          <Text variant="bodySmall" style={styles.metadataText}>
+            登録: {new Date(client.createdAt).toLocaleString('ja-JP')}
+          </Text>
+          {client.updatedAt !== client.createdAt && (
+            <Text variant="bodySmall" style={styles.metadataText}>
+              更新: {new Date(client.updatedAt).toLocaleString('ja-JP')}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    backgroundColor: '#FFFFFF',
+  },
+  headerTitle: {
+    fontWeight: '600',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  card: {
+    marginBottom: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  nameSection: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  nameContainer: {
+    flex: 1,
+  },
+  clientName: {
+    fontWeight: '600',
+  },
+  nameKana: {
+    color: '#757575',
+    marginTop: 2,
+  },
+  inactiveChip: {
+    backgroundColor: '#FFEBEE',
+  },
+  inactiveChipText: {
+    color: '#C62828',
+    fontSize: 12,
+  },
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 12,
+  },
+  careLevelChip: {
+    height: 28,
+  },
+  genderChip: {
+    backgroundColor: '#E0E0E0',
+    height: 28,
+  },
+  ageChip: {
+    backgroundColor: '#E8F5E9',
+    height: 28,
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  label: {
+    width: 80,
+    color: '#757575',
+  },
+  value: {
+    flex: 1,
+    color: '#212121',
+  },
+  phoneRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  phoneInfo: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+  },
+  divider: {
+    marginVertical: 12,
+  },
+  assessmentText: {
+    color: '#424242',
+    lineHeight: 22,
+  },
+  servicesText: {
+    color: '#424242',
+    lineHeight: 22,
+  },
+  notesText: {
+    color: '#424242',
+    lineHeight: 22,
+  },
+  metadata: {
+    marginTop: 8,
+    paddingHorizontal: 4,
+  },
+  metadataText: {
+    color: '#9E9E9E',
+    marginBottom: 4,
+  },
+});

--- a/mobile/src/screens/clients/ClientListScreen.tsx
+++ b/mobile/src/screens/clients/ClientListScreen.tsx
@@ -1,21 +1,227 @@
-import React from 'react';
-import { View, StyleSheet } from 'react-native';
-import { Text, useTheme } from 'react-native-paper';
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, StyleSheet, FlatList, RefreshControl, TouchableOpacity, Linking, Alert } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  Searchbar,
+  IconButton,
+} from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useStaff } from '../../hooks/useStaff';
+import { dataConnect } from '../../lib/firebase';
+import {
+  listClients,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+import { ClientStackParamList } from '../../navigation/RootNavigator';
+
+type Client = ListClientsData['clients'][0];
+
+type NavigationProp = NativeStackNavigationProp<ClientStackParamList, 'ClientList'>;
 
 export default function ClientListScreen() {
   const theme = useTheme();
+  const navigation = useNavigation<NavigationProp>();
+  const { facilityId, loading: staffLoading } = useStaff();
+
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const res = await listClients(dataConnect, { facilityId });
+      setClients(res.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load clients:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  const handleClientPress = (client: Client) => {
+    navigation.navigate('ClientDetail', { clientId: client.id });
+  };
+
+  const handlePhonePress = (phone: string | null | undefined, clientName: string) => {
+    if (!phone) {
+      Alert.alert('電話番号なし', 'この利用者の電話番号は登録されていません');
+      return;
+    }
+
+    Alert.alert(
+      '電話をかける',
+      `${clientName}さんに電話をかけますか？\n${phone}`,
+      [
+        { text: 'キャンセル', style: 'cancel' },
+        { text: '電話する', onPress: () => Linking.openURL(`tel:${phone}`) },
+      ]
+    );
+  };
+
+  const filteredClients = clients.filter((client) => {
+    if (!searchQuery) return true;
+    const query = searchQuery.toLowerCase();
+    return (
+      client.name.toLowerCase().includes(query) ||
+      (client.nameKana && client.nameKana.toLowerCase().includes(query))
+    );
+  });
+
+  const getAddress = (client: Client): string => {
+    const parts = [client.addressPrefecture, client.addressCity].filter(Boolean);
+    return parts.join(' ');
+  };
+
+  const renderClient = ({ item }: { item: Client }) => (
+    <TouchableOpacity onPress={() => handleClientPress(item)} activeOpacity={0.7}>
+      <Card style={styles.card} mode="elevated">
+        <Card.Content>
+          <View style={styles.cardHeader}>
+            <View style={styles.nameContainer}>
+              <Text variant="titleLarge" style={styles.clientName}>
+                {item.name}
+              </Text>
+              {item.nameKana && (
+                <Text variant="bodySmall" style={styles.nameKana}>
+                  {item.nameKana}
+                </Text>
+              )}
+            </View>
+            <IconButton
+              icon="phone"
+              size={24}
+              iconColor={item.phone ? theme.colors.primary : '#BDBDBD'}
+              onPress={(e) => {
+                e.stopPropagation();
+                handlePhonePress(item.phone, item.name);
+              }}
+            />
+          </View>
+
+          <View style={styles.infoRow}>
+            {item.careLevel?.name && (
+              <Chip
+                compact
+                style={[styles.careLevelChip, { backgroundColor: theme.colors.secondaryContainer }]}
+                textStyle={styles.chipText}
+              >
+                {item.careLevel.name}
+              </Chip>
+            )}
+            {item.gender && (
+              <Chip compact style={styles.genderChip} textStyle={styles.chipText}>
+                {item.gender}
+              </Chip>
+            )}
+          </View>
+
+          {getAddress(item) && (
+            <View style={styles.addressRow}>
+              <Text variant="bodyMedium" style={styles.addressText}>
+                📍 {getAddress(item)}
+              </Text>
+            </View>
+          )}
+        </Card.Content>
+      </Card>
+    </TouchableOpacity>
+  );
+
+  if (staffLoading || loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>スタッフ情報が見つかりません</Text>
+          <Text style={styles.subText}>管理者にお問い合わせください</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
-      <View style={styles.content}>
-        <Text variant="headlineMedium" style={{ color: theme.colors.primary }}>
+      <View style={styles.header}>
+        <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.primary }]}>
           利用者
         </Text>
-        <Text variant="bodyMedium" style={styles.placeholder}>
-          利用者一覧画面（実装予定）
+        <Text variant="bodyMedium" style={styles.countText}>
+          {filteredClients.length}名
         </Text>
       </View>
+
+      <Searchbar
+        placeholder="名前で検索..."
+        onChangeText={setSearchQuery}
+        value={searchQuery}
+        style={styles.searchbar}
+        inputStyle={styles.searchInput}
+      />
+
+      <FlatList
+        data={filteredClients}
+        renderItem={renderClient}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>
+              {searchQuery ? '該当する利用者が見つかりません' : '利用者が登録されていません'}
+            </Text>
+          </View>
+        }
+      />
     </SafeAreaView>
   );
 }
@@ -25,14 +231,98 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#FAFAFA',
   },
-  content: {
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  title: {
+    fontWeight: '600',
+  },
+  countText: {
+    color: '#757575',
+  },
+  searchbar: {
+    marginHorizontal: 16,
+    marginBottom: 8,
+    backgroundColor: '#FFFFFF',
+    elevation: 1,
+  },
+  searchInput: {
+    fontSize: 14,
+  },
+  loadingContainer: {
     flex: 1,
-    padding: 16,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  placeholder: {
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  subText: {
     marginTop: 8,
+    color: '#757575',
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 8,
+  },
+  card: {
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+  },
+  nameContainer: {
+    flex: 1,
+  },
+  clientName: {
+    fontWeight: '600',
+  },
+  nameKana: {
+    color: '#757575',
+    marginTop: 2,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 8,
+    gap: 8,
+  },
+  careLevelChip: {
+    height: 28,
+  },
+  genderChip: {
+    backgroundColor: '#E0E0E0',
+    height: 28,
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  addressRow: {
+    marginTop: 8,
+  },
+  addressText: {
+    color: '#616161',
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+  },
+  emptyText: {
+    fontSize: 16,
     color: '#757575',
   },
 });


### PR DESCRIPTION
## Summary
- モバイル版利用者一覧画面の実装（検索、電話発信、カード表示）
- モバイル版利用者詳細画面の実装（基本情報、連絡先、緊急連絡先、ケア情報）
- 利用者画面用スタックナビゲーションの追加

## Test plan
- [ ] 利用者一覧画面で利用者が表示されることを確認
- [ ] 検索バーで名前検索できることを確認
- [ ] 電話アイコンタップで発信確認ダイアログが表示されることを確認
- [ ] カードタップで詳細画面に遷移することを確認
- [ ] 詳細画面で各情報が正しく表示されることを確認
- [ ] 戻るボタンで一覧に戻れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)