### PR TITLE
Add care plan PDF generation feature

### DIFF
--- a/dataconnect/connector/mutations.gql
+++ b/dataconnect/connector/mutations.gql
@@ -287,6 +287,29 @@ mutation CreateCarePlan(
   })
 }
 
+mutation UpdateCarePlan(
+  $id: UUID!
+  $currentSituation: String
+  $familyWishes: String
+  $mainSupport: String
+  $longTermGoals: Any
+  $shortTermGoals: Any
+  $pdfUrl: String
+) @auth(level: USER) {
+  carePlan_update(id: $id, data: {
+    currentSituation: $currentSituation
+    familyWishes: $familyWishes
+    mainSupport: $mainSupport
+    longTermGoals: $longTermGoals
+    shortTermGoals: $shortTermGoals
+    pdfUrl: $pdfUrl
+  })
+}
+
+mutation DeleteCarePlan($id: UUID!) @auth(level: USER) {
+  carePlan_delete(id: $id)
+}
+
 # ---------------------
 # マスタデータ初期化（管理者用）
 # ---------------------

--- a/dataconnect/connector/queries.gql
+++ b/dataconnect/connector/queries.gql
@@ -341,3 +341,62 @@ query ListCarePlansByClient($clientId: UUID!) @auth(level: USER) {
     createdAt
   }
 }
+
+query ListCarePlansByFacility($facilityId: UUID!) @auth(level: USER) {
+  carePlans(
+    where: { client: { facility: { id: { eq: $facilityId } } } }
+    orderBy: [{ createdAt: DESC }]
+  ) {
+    id
+    currentSituation
+    familyWishes
+    mainSupport
+    longTermGoals
+    shortTermGoals
+    pdfUrl
+    createdAt
+    client {
+      id
+      name
+    }
+    staff {
+      id
+      name
+    }
+  }
+}
+
+query GetCarePlan($id: UUID!) @auth(level: USER) {
+  carePlan(id: $id) {
+    id
+    currentSituation
+    familyWishes
+    mainSupport
+    longTermGoals
+    shortTermGoals
+    pdfUrl
+    createdAt
+    updatedAt
+    client {
+      id
+      name
+      careLevel {
+        name
+      }
+    }
+    staff {
+      id
+      name
+    }
+  }
+}
+
+query ListGoalTemplates @auth(level: USER) {
+  goalTemplates(orderBy: [{ sortOrder: ASC }]) {
+    id
+    supportType
+    goalType
+    content
+    sortOrder
+  }
+}

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,4 +1,4 @@
-# 作業状態 - 2026-01-10 (PDF Report Generation)
+# 作業状態 - 2026-01-10 (Care Plan PDF Generation)
 
 ## プロジェクト概要
 
@@ -352,38 +352,36 @@ web/
 
 ## 今セッション完了作業
 
-- [x] PDF帳票生成機能（実施報告書）実装
-  - Cloud Storage設定（firebase.json, storage.rules）
-  - pdfkit + 日本語フォント（IPAexゴシック）導入
-  - generateReport Cloud Function実装
-    - PostgreSQL直接接続で訪問記録取得
-    - pdfkitでPDF生成
+- [x] 訪問介護計画書PDF生成機能
+  - Data Connectクエリ追加（ListCarePlansByFacility, GetCarePlan, ListGoalTemplates）
+  - Data Connectミューテーション追加（UpdateCarePlan, DeleteCarePlan）
+  - generateCarePlan Cloud Function実装
+    - 利用者情報取得（PostgreSQL直接接続）
+    - pdfkitで計画書PDF生成（利用者情報、生活現状、意向、支援内容、長期/短期目標）
     - Cloud Storageにアップロード
-    - AI月次要約生成（Vertex AI Gemini）
-  - Web報告書画面実装（web/src/app/reports/page.tsx）
-    - 報告書一覧テーブル
-    - 報告書作成ダイアログ
+    - care_plansテーブル保存/更新
+  - Web計画書管理画面実装（web/src/app/careplans/page.tsx）
+    - 計画書一覧テーブル
+    - 計画書作成/編集ダイアログ（長期目標×3、短期目標×3）
     - Cloud Function呼び出し
-  - Data Connect クエリ追加（ListReportsByFacility）
-  - Cloud Functionsデプロイ完了（generateReport）
-- [x] Cloud Storageバケット作成（CLIで）
-  - `gsutil mb` でカスタムバケット `sanwa-houkai-app-reports` 作成
-  - Cloud Functionsサービスアカウントに objectAdmin 権限付与
-  - バケット名をデフォルト（firebasestorage.app）からカスタムに変更
+  - サイドバーに「計画書」リンク追加
+  - Cloud Functionsデプロイ完了（generateCarePlan）
 
 ### 前セッション完了作業（参考）
 
+- [x] PDF帳票生成機能（実施報告書）- generateReport
+- [x] Cloud Storageバケット作成（sanwa-houkai-app-reports）
 - [x] Firestoreルールデプロイ（リアルタイム同期有効化）
 - [x] スケジュールリアルタイム同期機能 - PR #26
 - [x] AI特記事項生成機能 - PR #25
 
 ## 次回アクション
 
-1. 訪問介護計画書PDF生成機能
-2. 繰り返し予定機能（毎週/毎月の定期スケジュール）
+1. 繰り返し予定機能（毎週/毎月の定期スケジュール）
+2. モバイルアプリでの計画書表示機能
 
 **デプロイ済み:**
-- Cloud Functions（generateVisitNotes, generateReport）- 2026-01-10 デプロイ完了
+- Cloud Functions（generateVisitNotes, generateReport, generateCarePlan）- 2026-01-10 デプロイ完了
 - Cloud Storageバケット（sanwa-houkai-app-reports）- 2026-01-10 作成完了
 - リアルタイム同期コード - 2026-01-10 マージ完了
 - Firestoreルール - 2026-01-10 デプロイ完了

--- a/mobile/src/generated/dataconnect/README.md
+++ b/mobile/src/generated/dataconnect/README.md
@@ -24,6 +24,9 @@ This README will guide you through the process of using the generated JavaScript
   - [*ListReportsByClient*](#listreportsbyclient)
   - [*ListReportsByFacility*](#listreportsbyfacility)
   - [*ListCarePlansByClient*](#listcareplansbyclient)
+  - [*ListCarePlansByFacility*](#listcareplansbyfacility)
+  - [*GetCarePlan*](#getcareplan)
+  - [*ListGoalTemplates*](#listgoaltemplates)
 - [**Mutations**](#mutations)
   - [*CreateClient*](#createclient)
   - [*UpdateClient*](#updateclient)
@@ -39,6 +42,8 @@ This README will guide you through the process of using the generated JavaScript
   - [*CreateReport*](#createreport)
   - [*UpdateReportPdf*](#updatereportpdf)
   - [*CreateCarePlan*](#createcareplan)
+  - [*UpdateCarePlan*](#updatecareplan)
+  - [*DeleteCarePlan*](#deletecareplan)
   - [*SeedCareLevel*](#seedcarelevel)
   - [*SeedVisitReason*](#seedvisitreason)
   - [*CreateFacility*](#createfacility)
@@ -2026,6 +2031,359 @@ executeQuery(ref).then((response) => {
 });
 ```
 
+## ListCarePlansByFacility
+You can execute the `ListCarePlansByFacility` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface ListCarePlansByFacilityRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface ListCarePlansByFacilityRef {
+  ...
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the listCarePlansByFacilityRef:
+```typescript
+const name = listCarePlansByFacilityRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface ListCarePlansByFacilityVariables {
+  facilityId: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `ListCarePlansByFacility` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `ListCarePlansByFacilityData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface ListCarePlansByFacilityData {
+  carePlans: ({
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key)[];
+}
+```
+### Using `ListCarePlansByFacility`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, listCarePlansByFacility, ListCarePlansByFacilityVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`:
+const listCarePlansByFacilityVars: ListCarePlansByFacilityVariables = {
+  facilityId: ..., 
+};
+
+// Call the `listCarePlansByFacility()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await listCarePlansByFacility(listCarePlansByFacilityVars);
+// Variables can be defined inline as well.
+const { data } = await listCarePlansByFacility({ facilityId: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await listCarePlansByFacility(dataConnect, listCarePlansByFacilityVars);
+
+console.log(data.carePlans);
+
+// Or, you can use the `Promise` API.
+listCarePlansByFacility(listCarePlansByFacilityVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlans);
+});
+```
+
+### Using `ListCarePlansByFacility`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, listCarePlansByFacilityRef, ListCarePlansByFacilityVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`:
+const listCarePlansByFacilityVars: ListCarePlansByFacilityVariables = {
+  facilityId: ..., 
+};
+
+// Call the `listCarePlansByFacilityRef()` function to get a reference to the query.
+const ref = listCarePlansByFacilityRef(listCarePlansByFacilityVars);
+// Variables can be defined inline as well.
+const ref = listCarePlansByFacilityRef({ facilityId: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = listCarePlansByFacilityRef(dataConnect, listCarePlansByFacilityVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.carePlans);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlans);
+});
+```
+
+## GetCarePlan
+You can execute the `GetCarePlan` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface GetCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+}
+export const getCarePlanRef: GetCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface GetCarePlanRef {
+  ...
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+}
+export const getCarePlanRef: GetCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getCarePlanRef:
+```typescript
+const name = getCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetCarePlanVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetCarePlan` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetCarePlanData {
+  carePlan?: {
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key;
+}
+```
+### Using `GetCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getCarePlan, GetCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`:
+const getCarePlanVars: GetCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `getCarePlan()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getCarePlan(getCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await getCarePlan({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getCarePlan(dataConnect, getCarePlanVars);
+
+console.log(data.carePlan);
+
+// Or, you can use the `Promise` API.
+getCarePlan(getCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan);
+});
+```
+
+### Using `GetCarePlan`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getCarePlanRef, GetCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`:
+const getCarePlanVars: GetCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `getCarePlanRef()` function to get a reference to the query.
+const ref = getCarePlanRef(getCarePlanVars);
+// Variables can be defined inline as well.
+const ref = getCarePlanRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getCarePlanRef(dataConnect, getCarePlanVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.carePlan);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan);
+});
+```
+
+## ListGoalTemplates
+You can execute the `ListGoalTemplates` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+
+interface ListGoalTemplatesRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
+
+interface ListGoalTemplatesRef {
+  ...
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the listGoalTemplatesRef:
+```typescript
+const name = listGoalTemplatesRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `ListGoalTemplates` query has no variables.
+### Return Type
+Recall that executing the `ListGoalTemplates` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `ListGoalTemplatesData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface ListGoalTemplatesData {
+  goalTemplates: ({
+    id: UUIDString;
+    supportType: string;
+    goalType: string;
+    content: string;
+    sortOrder?: number | null;
+  } & GoalTemplate_Key)[];
+}
+```
+### Using `ListGoalTemplates`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, listGoalTemplates } from '@sanwa-houkai-app/dataconnect';
+
+
+// Call the `listGoalTemplates()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await listGoalTemplates();
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await listGoalTemplates(dataConnect);
+
+console.log(data.goalTemplates);
+
+// Or, you can use the `Promise` API.
+listGoalTemplates().then((response) => {
+  const data = response.data;
+  console.log(data.goalTemplates);
+});
+```
+
+### Using `ListGoalTemplates`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, listGoalTemplatesRef } from '@sanwa-houkai-app/dataconnect';
+
+
+// Call the `listGoalTemplatesRef()` function to get a reference to the query.
+const ref = listGoalTemplatesRef();
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = listGoalTemplatesRef(dataConnect);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.goalTemplates);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.goalTemplates);
+});
+```
+
 # Mutations
 
 There are two ways to execute a Data Connect Mutation using the generated Web SDK:
@@ -3834,6 +4192,242 @@ console.log(data.carePlan_insert);
 executeMutation(ref).then((response) => {
   const data = response.data;
   console.log(data.carePlan_insert);
+});
+```
+
+## UpdateCarePlan
+You can execute the `UpdateCarePlan` mutation using the following action shortcut function, or by calling `executeMutation()` after calling the following `MutationRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+updateCarePlan(vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `MutationRef` function.
+```typescript
+updateCarePlan(dc: DataConnect, vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  ...
+  (dc: DataConnect, vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the updateCarePlanRef:
+```typescript
+const name = updateCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface UpdateCarePlanVariables {
+  id: UUIDString;
+  currentSituation?: string | null;
+  familyWishes?: string | null;
+  mainSupport?: string | null;
+  longTermGoals?: unknown | null;
+  shortTermGoals?: unknown | null;
+  pdfUrl?: string | null;
+}
+```
+### Return Type
+Recall that executing the `UpdateCarePlan` mutation returns a `MutationPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `UpdateCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface UpdateCarePlanData {
+  carePlan_update?: CarePlan_Key | null;
+}
+```
+### Using `UpdateCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, updateCarePlan, UpdateCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`:
+const updateCarePlanVars: UpdateCarePlanVariables = {
+  id: ..., 
+  currentSituation: ..., // optional
+  familyWishes: ..., // optional
+  mainSupport: ..., // optional
+  longTermGoals: ..., // optional
+  shortTermGoals: ..., // optional
+  pdfUrl: ..., // optional
+};
+
+// Call the `updateCarePlan()` function to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await updateCarePlan(updateCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await updateCarePlan({ id: ..., currentSituation: ..., familyWishes: ..., mainSupport: ..., longTermGoals: ..., shortTermGoals: ..., pdfUrl: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await updateCarePlan(dataConnect, updateCarePlanVars);
+
+console.log(data.carePlan_update);
+
+// Or, you can use the `Promise` API.
+updateCarePlan(updateCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_update);
+});
+```
+
+### Using `UpdateCarePlan`'s `MutationRef` function
+
+```typescript
+import { getDataConnect, executeMutation } from 'firebase/data-connect';
+import { connectorConfig, updateCarePlanRef, UpdateCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`:
+const updateCarePlanVars: UpdateCarePlanVariables = {
+  id: ..., 
+  currentSituation: ..., // optional
+  familyWishes: ..., // optional
+  mainSupport: ..., // optional
+  longTermGoals: ..., // optional
+  shortTermGoals: ..., // optional
+  pdfUrl: ..., // optional
+};
+
+// Call the `updateCarePlanRef()` function to get a reference to the mutation.
+const ref = updateCarePlanRef(updateCarePlanVars);
+// Variables can be defined inline as well.
+const ref = updateCarePlanRef({ id: ..., currentSituation: ..., familyWishes: ..., mainSupport: ..., longTermGoals: ..., shortTermGoals: ..., pdfUrl: ..., });
+
+// You can also pass in a `DataConnect` instance to the `MutationRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = updateCarePlanRef(dataConnect, updateCarePlanVars);
+
+// Call `executeMutation()` on the reference to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeMutation(ref);
+
+console.log(data.carePlan_update);
+
+// Or, you can use the `Promise` API.
+executeMutation(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_update);
+});
+```
+
+## DeleteCarePlan
+You can execute the `DeleteCarePlan` mutation using the following action shortcut function, or by calling `executeMutation()` after calling the following `MutationRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+deleteCarePlan(vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `MutationRef` function.
+```typescript
+deleteCarePlan(dc: DataConnect, vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  ...
+  (dc: DataConnect, vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the deleteCarePlanRef:
+```typescript
+const name = deleteCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface DeleteCarePlanVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `DeleteCarePlan` mutation returns a `MutationPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `DeleteCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface DeleteCarePlanData {
+  carePlan_delete?: CarePlan_Key | null;
+}
+```
+### Using `DeleteCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, deleteCarePlan, DeleteCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`:
+const deleteCarePlanVars: DeleteCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `deleteCarePlan()` function to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await deleteCarePlan(deleteCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await deleteCarePlan({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await deleteCarePlan(dataConnect, deleteCarePlanVars);
+
+console.log(data.carePlan_delete);
+
+// Or, you can use the `Promise` API.
+deleteCarePlan(deleteCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_delete);
+});
+```
+
+### Using `DeleteCarePlan`'s `MutationRef` function
+
+```typescript
+import { getDataConnect, executeMutation } from 'firebase/data-connect';
+import { connectorConfig, deleteCarePlanRef, DeleteCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`:
+const deleteCarePlanVars: DeleteCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `deleteCarePlanRef()` function to get a reference to the mutation.
+const ref = deleteCarePlanRef(deleteCarePlanVars);
+// Variables can be defined inline as well.
+const ref = deleteCarePlanRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `MutationRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = deleteCarePlanRef(dataConnect, deleteCarePlanVars);
+
+// Call `executeMutation()` on the reference to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeMutation(ref);
+
+console.log(data.carePlan_delete);
+
+// Or, you can use the `Promise` API.
+executeMutation(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_delete);
 });
 ```
 

--- a/mobile/src/generated/dataconnect/esm/index.esm.js
+++ b/mobile/src/generated/dataconnect/esm/index.esm.js
@@ -160,6 +160,28 @@ export function createCarePlan(dcOrVars, vars) {
   return executeMutation(createCarePlanRef(dcOrVars, vars));
 }
 
+export const updateCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'UpdateCarePlan', inputVars);
+}
+updateCarePlanRef.operationName = 'UpdateCarePlan';
+
+export function updateCarePlan(dcOrVars, vars) {
+  return executeMutation(updateCarePlanRef(dcOrVars, vars));
+}
+
+export const deleteCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'DeleteCarePlan', inputVars);
+}
+deleteCarePlanRef.operationName = 'DeleteCarePlan';
+
+export function deleteCarePlan(dcOrVars, vars) {
+  return executeMutation(deleteCarePlanRef(dcOrVars, vars));
+}
+
 export const seedCareLevelRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -400,5 +422,38 @@ listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
 
 export function listCarePlansByClient(dcOrVars, vars) {
   return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+}
+
+export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+
+export function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+}
+
+export const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+
+export function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+}
+
+export const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+
+export function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
 }
 

--- a/mobile/src/generated/dataconnect/index.cjs.js
+++ b/mobile/src/generated/dataconnect/index.cjs.js
@@ -175,6 +175,30 @@ exports.createCarePlan = function createCarePlan(dcOrVars, vars) {
   return executeMutation(createCarePlanRef(dcOrVars, vars));
 };
 
+const updateCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'UpdateCarePlan', inputVars);
+}
+updateCarePlanRef.operationName = 'UpdateCarePlan';
+exports.updateCarePlanRef = updateCarePlanRef;
+
+exports.updateCarePlan = function updateCarePlan(dcOrVars, vars) {
+  return executeMutation(updateCarePlanRef(dcOrVars, vars));
+};
+
+const deleteCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'DeleteCarePlan', inputVars);
+}
+deleteCarePlanRef.operationName = 'DeleteCarePlan';
+exports.deleteCarePlanRef = deleteCarePlanRef;
+
+exports.deleteCarePlan = function deleteCarePlan(dcOrVars, vars) {
+  return executeMutation(deleteCarePlanRef(dcOrVars, vars));
+};
+
 const seedCareLevelRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -437,4 +461,40 @@ exports.listCarePlansByClientRef = listCarePlansByClientRef;
 
 exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
   return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+};
+
+const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
+
+exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+};
+
+const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+exports.getCarePlanRef = getCarePlanRef;
+
+exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+};
+
+const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+exports.listGoalTemplatesRef = listGoalTemplatesRef;
+
+exports.listGoalTemplates = function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
 };

--- a/mobile/src/generated/dataconnect/index.d.ts
+++ b/mobile/src/generated/dataconnect/index.d.ts
@@ -178,6 +178,14 @@ export interface CreateVisitRecordVariables {
   attachments?: string[] | null;
 }
 
+export interface DeleteCarePlanData {
+  carePlan_delete?: CarePlan_Key | null;
+}
+
+export interface DeleteCarePlanVariables {
+  id: UUIDString;
+}
+
 export interface DeleteClientData {
   client_update?: Client_Key | null;
 }
@@ -205,6 +213,35 @@ export interface DeleteVisitRecordVariables {
 export interface Facility_Key {
   id: UUIDString;
   __typename?: 'Facility_Key';
+}
+
+export interface GetCarePlanData {
+  carePlan?: {
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key;
+}
+
+export interface GetCarePlanVariables {
+  id: UUIDString;
 }
 
 export interface GetClientData {
@@ -329,6 +366,31 @@ export interface ListCarePlansByClientVariables {
   clientId: UUIDString;
 }
 
+export interface ListCarePlansByFacilityData {
+  carePlans: ({
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key)[];
+}
+
+export interface ListCarePlansByFacilityVariables {
+  facilityId: UUIDString;
+}
+
 export interface ListClientsData {
   clients: ({
     id: UUIDString;
@@ -346,6 +408,16 @@ export interface ListClientsData {
 
 export interface ListClientsVariables {
   facilityId: UUIDString;
+}
+
+export interface ListGoalTemplatesData {
+  goalTemplates: ({
+    id: UUIDString;
+    supportType: string;
+    goalType: string;
+    content: string;
+    sortOrder?: number | null;
+  } & GoalTemplate_Key)[];
 }
 
 export interface ListReportsByClientData {
@@ -591,6 +663,20 @@ export interface ServiceType_Key {
 export interface Staff_Key {
   id: UUIDString;
   __typename?: 'Staff_Key';
+}
+
+export interface UpdateCarePlanData {
+  carePlan_update?: CarePlan_Key | null;
+}
+
+export interface UpdateCarePlanVariables {
+  id: UUIDString;
+  currentSituation?: string | null;
+  familyWishes?: string | null;
+  mainSupport?: string | null;
+  longTermGoals?: unknown | null;
+  shortTermGoals?: unknown | null;
+  pdfUrl?: string | null;
 }
 
 export interface UpdateClientData {
@@ -840,6 +926,30 @@ export const createCarePlanRef: CreateCarePlanRef;
 
 export function createCarePlan(vars: CreateCarePlanVariables): MutationPromise<CreateCarePlanData, CreateCarePlanVariables>;
 export function createCarePlan(dc: DataConnect, vars: CreateCarePlanVariables): MutationPromise<CreateCarePlanData, CreateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+  operationName: string;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+
+export function updateCarePlan(vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+export function updateCarePlan(dc: DataConnect, vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+  operationName: string;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+
+export function deleteCarePlan(vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+export function deleteCarePlan(dc: DataConnect, vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
 
 interface SeedCareLevelRef {
   /* Allow users to create refs without passing in DataConnect */
@@ -1104,4 +1214,40 @@ export const listCarePlansByClientRef: ListCarePlansByClientRef;
 
 export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
 export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+
+interface ListCarePlansByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  operationName: string;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+
+export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface GetCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  operationName: string;
+}
+export const getCarePlanRef: GetCarePlanRef;
+
+export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface ListGoalTemplatesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+  operationName: string;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+
+export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
 

--- a/web/src/app/careplans/page.tsx
+++ b/web/src/app/careplans/page.tsx
@@ -1,0 +1,662 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Chip,
+  IconButton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Alert,
+  Tooltip,
+  TablePagination,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  Snackbar,
+  Divider,
+} from '@mui/material';
+import {
+  Add as AddIcon,
+  Refresh as RefreshIcon,
+  Download as DownloadIcon,
+  Edit as EditIcon,
+} from '@mui/icons-material';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { MainLayout } from '@/components/layout';
+import { useStaff } from '@/hooks/useStaff';
+import { dataConnect, functions, httpsCallable } from '@/lib/firebase';
+import {
+  listCarePlansByFacility,
+  listClients,
+  ListCarePlansByFacilityData,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+
+type CarePlan = ListCarePlansByFacilityData['carePlans'][0];
+type Client = ListClientsData['clients'][0];
+
+interface Goal {
+  content: string;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+interface GenerateCarePlanRequest {
+  carePlanId?: string;
+  clientId: string;
+  staffId: string;
+  currentSituation: string;
+  familyWishes: string;
+  mainSupport: string;
+  longTermGoals: Goal[];
+  shortTermGoals: Goal[];
+}
+
+interface GenerateCarePlanResponse {
+  success: boolean;
+  pdfUrl: string;
+}
+
+const ROWS_PER_PAGE_OPTIONS = [10, 25, 50];
+
+const emptyGoal = (): Goal => ({
+  content: '',
+  startDate: null,
+  endDate: null,
+});
+
+export default function CarePlansPage() {
+  const { staff, facilityId, loading: staffLoading } = useStaff();
+
+  const [carePlans, setCarePlans] = useState<CarePlan[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter & pagination state
+  const [filterClientId, setFilterClientId] = useState<string>('');
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingCarePlanId, setEditingCarePlanId] = useState<string | null>(null);
+  const [selectedClientId, setSelectedClientId] = useState<string>('');
+  const [currentSituation, setCurrentSituation] = useState('');
+  const [familyWishes, setFamilyWishes] = useState('');
+  const [mainSupport, setMainSupport] = useState('');
+  const [longTermGoals, setLongTermGoals] = useState<Goal[]>([emptyGoal(), emptyGoal(), emptyGoal()]);
+  const [shortTermGoals, setShortTermGoals] = useState<Goal[]>([emptyGoal(), emptyGoal(), emptyGoal()]);
+  const [generating, setGenerating] = useState(false);
+
+  // Snackbar state
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState('');
+  const [snackbarSeverity, setSnackbarSeverity] = useState<'success' | 'error'>('success');
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const [carePlansRes, clientsRes] = await Promise.all([
+        listCarePlansByFacility(dataConnect, { facilityId }),
+        listClients(dataConnect, { facilityId }),
+      ]);
+
+      setCarePlans(carePlansRes.data.carePlans);
+      setClients(clientsRes.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load care plans:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setLoading(true);
+    await fetchData();
+    setLoading(false);
+  };
+
+  const resetForm = () => {
+    setEditingCarePlanId(null);
+    setSelectedClientId('');
+    setCurrentSituation('');
+    setFamilyWishes('');
+    setMainSupport('');
+    setLongTermGoals([emptyGoal(), emptyGoal(), emptyGoal()]);
+    setShortTermGoals([emptyGoal(), emptyGoal(), emptyGoal()]);
+  };
+
+  const handleOpenDialog = () => {
+    resetForm();
+    setDialogOpen(true);
+  };
+
+  const handleEditCarePlan = (carePlan: CarePlan) => {
+    setEditingCarePlanId(carePlan.id);
+    setSelectedClientId(carePlan.client.id);
+    setCurrentSituation(carePlan.currentSituation || '');
+    setFamilyWishes(carePlan.familyWishes || '');
+    setMainSupport(carePlan.mainSupport || '');
+
+    // Parse goals from JSON
+    const parsedLongTermGoals = carePlan.longTermGoals as Goal[] | null;
+    const parsedShortTermGoals = carePlan.shortTermGoals as Goal[] | null;
+
+    setLongTermGoals(
+      parsedLongTermGoals && parsedLongTermGoals.length > 0
+        ? [...parsedLongTermGoals, ...Array(3 - parsedLongTermGoals.length).fill(emptyGoal())].slice(0, 3)
+        : [emptyGoal(), emptyGoal(), emptyGoal()]
+    );
+    setShortTermGoals(
+      parsedShortTermGoals && parsedShortTermGoals.length > 0
+        ? [...parsedShortTermGoals, ...Array(3 - parsedShortTermGoals.length).fill(emptyGoal())].slice(0, 3)
+        : [emptyGoal(), emptyGoal(), emptyGoal()]
+    );
+
+    setDialogOpen(true);
+  };
+
+  const handleCloseDialog = () => {
+    if (!generating) {
+      setDialogOpen(false);
+    }
+  };
+
+  const updateGoal = (
+    goals: Goal[],
+    setGoals: React.Dispatch<React.SetStateAction<Goal[]>>,
+    index: number,
+    field: keyof Goal,
+    value: string | Date | null
+  ) => {
+    const newGoals = [...goals];
+    if (field === 'startDate' || field === 'endDate') {
+      newGoals[index] = {
+        ...newGoals[index],
+        [field]: value instanceof Date ? value.toISOString().split('T')[0] : null,
+      };
+    } else {
+      newGoals[index] = {
+        ...newGoals[index],
+        [field]: value as string,
+      };
+    }
+    setGoals(newGoals);
+  };
+
+  const handleGenerateCarePlan = async () => {
+    if (!selectedClientId || !staff) {
+      setSnackbarMessage('利用者を選択してください');
+      setSnackbarSeverity('error');
+      setSnackbarOpen(true);
+      return;
+    }
+
+    if (!functions) {
+      setSnackbarMessage('Firebase Functionsが初期化されていません');
+      setSnackbarSeverity('error');
+      setSnackbarOpen(true);
+      return;
+    }
+
+    setGenerating(true);
+
+    try {
+      const generateCarePlan = httpsCallable<GenerateCarePlanRequest, GenerateCarePlanResponse>(
+        functions,
+        'generateCarePlan'
+      );
+
+      // Filter out empty goals
+      const filteredLongTermGoals = longTermGoals.filter((g) => g.content.trim());
+      const filteredShortTermGoals = shortTermGoals.filter((g) => g.content.trim());
+
+      const result = await generateCarePlan({
+        carePlanId: editingCarePlanId || undefined,
+        clientId: selectedClientId,
+        staffId: staff.id,
+        currentSituation,
+        familyWishes,
+        mainSupport,
+        longTermGoals: filteredLongTermGoals,
+        shortTermGoals: filteredShortTermGoals,
+      });
+
+      if (result.data.success) {
+        setSnackbarMessage(editingCarePlanId ? '計画書を更新しました' : '計画書を作成しました');
+        setSnackbarSeverity('success');
+        setSnackbarOpen(true);
+
+        // PDFをダウンロード
+        window.open(result.data.pdfUrl, '_blank');
+
+        // 一覧を更新
+        await fetchData();
+        setDialogOpen(false);
+      }
+    } catch (err) {
+      console.error('Failed to generate care plan:', err);
+      setSnackbarMessage('計画書の生成に失敗しました');
+      setSnackbarSeverity('error');
+      setSnackbarOpen(true);
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const handleDownload = (pdfUrl: string | null | undefined) => {
+    if (pdfUrl) {
+      window.open(pdfUrl, '_blank');
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const filteredCarePlans = filterClientId
+    ? carePlans.filter((cp) => cp.client.id === filterClientId)
+    : carePlans;
+
+  const paginatedCarePlans = filteredCarePlans.slice(
+    page * rowsPerPage,
+    page * rowsPerPage + rowsPerPage
+  );
+
+  const handleChangePage = (_: unknown, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRowsPerPage(parseInt(event.target.value, 10));
+    setPage(0);
+  };
+
+  if (staffLoading || loading) {
+    return (
+      <MainLayout title="訪問介護計画書">
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      </MainLayout>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <MainLayout title="訪問介護計画書">
+        <Alert severity="error">
+          スタッフ情報が見つかりません。管理者にお問い合わせください。
+        </Alert>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout title="訪問介護計画書">
+        <Alert severity="error">{error}</Alert>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout title="訪問介護計画書">
+      <Box>
+        {/* Header */}
+        <Card sx={{ mb: 3 }}>
+          <CardContent>
+            <Box display="flex" alignItems="center" gap={2} flexWrap="wrap">
+              <FormControl size="small" sx={{ minWidth: 200 }}>
+                <InputLabel>利用者で絞り込み</InputLabel>
+                <Select
+                  value={filterClientId}
+                  label="利用者で絞り込み"
+                  onChange={(e) => {
+                    setFilterClientId(e.target.value);
+                    setPage(0);
+                  }}
+                >
+                  <MenuItem value="">すべて表示</MenuItem>
+                  {clients.map((client) => (
+                    <MenuItem key={client.id} value={client.id}>
+                      {client.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+              <Tooltip title="更新">
+                <IconButton onClick={handleRefresh} color="primary">
+                  <RefreshIcon />
+                </IconButton>
+              </Tooltip>
+              <Box sx={{ ml: 'auto' }}>
+                <Button
+                  variant="contained"
+                  startIcon={<AddIcon />}
+                  onClick={handleOpenDialog}
+                >
+                  計画書を作成
+                </Button>
+              </Box>
+            </Box>
+          </CardContent>
+        </Card>
+
+        {/* Care Plans Table */}
+        <Card>
+          <TableContainer component={Paper} elevation={0}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>利用者</TableCell>
+                  <TableCell>主な支援内容</TableCell>
+                  <TableCell>長期目標</TableCell>
+                  <TableCell>短期目標</TableCell>
+                  <TableCell>作成日</TableCell>
+                  <TableCell>作成者</TableCell>
+                  <TableCell align="center">操作</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {paginatedCarePlans.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} align="center" sx={{ py: 8 }}>
+                      <Typography color="text.secondary">
+                        {filterClientId
+                          ? 'この利用者の計画書はありません'
+                          : '計画書がありません'}
+                      </Typography>
+                      <Button
+                        variant="outlined"
+                        startIcon={<AddIcon />}
+                        onClick={handleOpenDialog}
+                        sx={{ mt: 2 }}
+                      >
+                        計画書を作成
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  paginatedCarePlans.map((carePlan) => {
+                    const longTermGoalsData = carePlan.longTermGoals as Goal[] | null;
+                    const shortTermGoalsData = carePlan.shortTermGoals as Goal[] | null;
+                    const longTermCount = longTermGoalsData?.filter((g) => g.content)?.length || 0;
+                    const shortTermCount = shortTermGoalsData?.filter((g) => g.content)?.length || 0;
+
+                    return (
+                      <TableRow key={carePlan.id} hover>
+                        <TableCell>
+                          <Typography fontWeight={500}>{carePlan.client.name}</Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Typography
+                            variant="body2"
+                            sx={{
+                              maxWidth: 200,
+                              overflow: 'hidden',
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {carePlan.mainSupport || '（未設定）'}
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={`${longTermCount}件`}
+                            size="small"
+                            color={longTermCount > 0 ? 'primary' : 'default'}
+                            variant={longTermCount > 0 ? 'filled' : 'outlined'}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <Chip
+                            label={`${shortTermCount}件`}
+                            size="small"
+                            color={shortTermCount > 0 ? 'secondary' : 'default'}
+                            variant={shortTermCount > 0 ? 'filled' : 'outlined'}
+                          />
+                        </TableCell>
+                        <TableCell>{formatDate(carePlan.createdAt)}</TableCell>
+                        <TableCell>
+                          <Chip label={carePlan.staff.name} size="small" variant="outlined" />
+                        </TableCell>
+                        <TableCell align="center">
+                          <Tooltip title="編集">
+                            <IconButton
+                              size="small"
+                              color="primary"
+                              onClick={() => handleEditCarePlan(carePlan)}
+                            >
+                              <EditIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                          {carePlan.pdfUrl && (
+                            <Tooltip title="PDFをダウンロード">
+                              <IconButton
+                                size="small"
+                                color="primary"
+                                onClick={() => handleDownload(carePlan.pdfUrl)}
+                              >
+                                <DownloadIcon fontSize="small" />
+                              </IconButton>
+                            </Tooltip>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            rowsPerPageOptions={ROWS_PER_PAGE_OPTIONS}
+            component="div"
+            count={filteredCarePlans.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+            labelRowsPerPage="表示件数:"
+            labelDisplayedRows={({ from, to, count }) =>
+              `${from}-${to} / ${count}件`
+            }
+          />
+        </Card>
+
+        {/* Create/Edit Care Plan Dialog */}
+        <Dialog open={dialogOpen} onClose={handleCloseDialog} maxWidth="md" fullWidth>
+          <DialogTitle>
+            {editingCarePlanId ? '訪問介護計画書を編集' : '訪問介護計画書を作成'}
+          </DialogTitle>
+          <DialogContent>
+            <Box sx={{ pt: 2, display: 'flex', flexDirection: 'column', gap: 3 }}>
+              {/* 利用者選択 */}
+              <FormControl fullWidth disabled={!!editingCarePlanId}>
+                <InputLabel>利用者 *</InputLabel>
+                <Select
+                  value={selectedClientId}
+                  label="利用者 *"
+                  onChange={(e) => setSelectedClientId(e.target.value)}
+                  disabled={generating || !!editingCarePlanId}
+                >
+                  {clients.map((client) => (
+                    <MenuItem key={client.id} value={client.id}>
+                      {client.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <Divider />
+
+              {/* 基本情報 */}
+              <TextField
+                label="利用者の生活現状"
+                multiline
+                rows={3}
+                value={currentSituation}
+                onChange={(e) => setCurrentSituation(e.target.value)}
+                disabled={generating}
+                placeholder="利用者の現在の生活状況を記入してください"
+              />
+
+              <TextField
+                label="利用者及び家族の意向・希望"
+                multiline
+                rows={3}
+                value={familyWishes}
+                onChange={(e) => setFamilyWishes(e.target.value)}
+                disabled={generating}
+                placeholder="利用者及び家族の意向・希望を記入してください"
+              />
+
+              <TextField
+                label="主な支援内容"
+                multiline
+                rows={3}
+                value={mainSupport}
+                onChange={(e) => setMainSupport(e.target.value)}
+                disabled={generating}
+                placeholder="提供する主な支援内容を記入してください"
+              />
+
+              <Divider />
+
+              {/* 長期目標 */}
+              <Typography variant="subtitle1" fontWeight={600}>
+                長期目標（最大3件）
+              </Typography>
+              {longTermGoals.map((goal, index) => (
+                <Box key={`long-${index}`} sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+                  <TextField
+                    label={`長期目標 ${index + 1}`}
+                    fullWidth
+                    value={goal.content}
+                    onChange={(e) => updateGoal(longTermGoals, setLongTermGoals, index, 'content', e.target.value)}
+                    disabled={generating}
+                    size="small"
+                  />
+                  <DatePicker
+                    label="開始日"
+                    value={goal.startDate ? new Date(goal.startDate) : null}
+                    onChange={(date) => updateGoal(longTermGoals, setLongTermGoals, index, 'startDate', date)}
+                    disabled={generating}
+                    slotProps={{ textField: { size: 'small', sx: { minWidth: 150 } } }}
+                  />
+                  <DatePicker
+                    label="終了日"
+                    value={goal.endDate ? new Date(goal.endDate) : null}
+                    onChange={(date) => updateGoal(longTermGoals, setLongTermGoals, index, 'endDate', date)}
+                    disabled={generating}
+                    slotProps={{ textField: { size: 'small', sx: { minWidth: 150 } } }}
+                  />
+                </Box>
+              ))}
+
+              <Divider />
+
+              {/* 短期目標 */}
+              <Typography variant="subtitle1" fontWeight={600}>
+                短期目標（最大3件）
+              </Typography>
+              {shortTermGoals.map((goal, index) => (
+                <Box key={`short-${index}`} sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+                  <TextField
+                    label={`短期目標 ${index + 1}`}
+                    fullWidth
+                    value={goal.content}
+                    onChange={(e) => updateGoal(shortTermGoals, setShortTermGoals, index, 'content', e.target.value)}
+                    disabled={generating}
+                    size="small"
+                  />
+                  <DatePicker
+                    label="開始日"
+                    value={goal.startDate ? new Date(goal.startDate) : null}
+                    onChange={(date) => updateGoal(shortTermGoals, setShortTermGoals, index, 'startDate', date)}
+                    disabled={generating}
+                    slotProps={{ textField: { size: 'small', sx: { minWidth: 150 } } }}
+                  />
+                  <DatePicker
+                    label="終了日"
+                    value={goal.endDate ? new Date(goal.endDate) : null}
+                    onChange={(date) => updateGoal(shortTermGoals, setShortTermGoals, index, 'endDate', date)}
+                    disabled={generating}
+                    slotProps={{ textField: { size: 'small', sx: { minWidth: 150 } } }}
+                  />
+                </Box>
+              ))}
+
+              <Alert severity="info" sx={{ mt: 1 }}>
+                計画書の内容を入力し、PDFを生成します。生成されたPDFは自動的にダウンロードされます。
+              </Alert>
+            </Box>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleCloseDialog} disabled={generating}>
+              キャンセル
+            </Button>
+            <Button
+              variant="contained"
+              onClick={handleGenerateCarePlan}
+              disabled={generating || !selectedClientId}
+              startIcon={generating ? <CircularProgress size={20} /> : <AddIcon />}
+            >
+              {generating ? '生成中...' : editingCarePlanId ? '更新する' : '生成する'}
+            </Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Snackbar */}
+        <Snackbar
+          open={snackbarOpen}
+          autoHideDuration={6000}
+          onClose={() => setSnackbarOpen(false)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+        >
+          <Alert
+            onClose={() => setSnackbarOpen(false)}
+            severity={snackbarSeverity}
+            sx={{ width: '100%' }}
+          >
+            {snackbarMessage}
+          </Alert>
+        </Snackbar>
+      </Box>
+    </MainLayout>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import {
   People as ClientsIcon,
   Person as StaffIcon,
   Description as ReportIcon,
+  Assignment as CarePlanIcon,
   Settings as SettingsIcon,
 } from '@mui/icons-material';
 
@@ -33,7 +34,8 @@ const menuItems = [
   { text: 'スケジュール', icon: <ScheduleIcon />, href: '/schedule' },
   { text: '利用者管理', icon: <ClientsIcon />, href: '/clients' },
   { text: '支援者管理', icon: <StaffIcon />, href: '/staff' },
-  { text: '帳票・報告', icon: <ReportIcon />, href: '/reports' },
+  { text: '実施報告書', icon: <ReportIcon />, href: '/reports' },
+  { text: '計画書', icon: <CarePlanIcon />, href: '/careplans' },
 ];
 
 const settingsItems = [

--- a/web/src/generated/dataconnect/README.md
+++ b/web/src/generated/dataconnect/README.md
@@ -24,6 +24,9 @@ This README will guide you through the process of using the generated JavaScript
   - [*ListReportsByClient*](#listreportsbyclient)
   - [*ListReportsByFacility*](#listreportsbyfacility)
   - [*ListCarePlansByClient*](#listcareplansbyclient)
+  - [*ListCarePlansByFacility*](#listcareplansbyfacility)
+  - [*GetCarePlan*](#getcareplan)
+  - [*ListGoalTemplates*](#listgoaltemplates)
 - [**Mutations**](#mutations)
   - [*CreateClient*](#createclient)
   - [*UpdateClient*](#updateclient)
@@ -39,6 +42,8 @@ This README will guide you through the process of using the generated JavaScript
   - [*CreateReport*](#createreport)
   - [*UpdateReportPdf*](#updatereportpdf)
   - [*CreateCarePlan*](#createcareplan)
+  - [*UpdateCarePlan*](#updatecareplan)
+  - [*DeleteCarePlan*](#deletecareplan)
   - [*SeedCareLevel*](#seedcarelevel)
   - [*SeedVisitReason*](#seedvisitreason)
   - [*CreateFacility*](#createfacility)
@@ -2026,6 +2031,359 @@ executeQuery(ref).then((response) => {
 });
 ```
 
+## ListCarePlansByFacility
+You can execute the `ListCarePlansByFacility` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface ListCarePlansByFacilityRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface ListCarePlansByFacilityRef {
+  ...
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the listCarePlansByFacilityRef:
+```typescript
+const name = listCarePlansByFacilityRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface ListCarePlansByFacilityVariables {
+  facilityId: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `ListCarePlansByFacility` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `ListCarePlansByFacilityData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface ListCarePlansByFacilityData {
+  carePlans: ({
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key)[];
+}
+```
+### Using `ListCarePlansByFacility`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, listCarePlansByFacility, ListCarePlansByFacilityVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`:
+const listCarePlansByFacilityVars: ListCarePlansByFacilityVariables = {
+  facilityId: ..., 
+};
+
+// Call the `listCarePlansByFacility()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await listCarePlansByFacility(listCarePlansByFacilityVars);
+// Variables can be defined inline as well.
+const { data } = await listCarePlansByFacility({ facilityId: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await listCarePlansByFacility(dataConnect, listCarePlansByFacilityVars);
+
+console.log(data.carePlans);
+
+// Or, you can use the `Promise` API.
+listCarePlansByFacility(listCarePlansByFacilityVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlans);
+});
+```
+
+### Using `ListCarePlansByFacility`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, listCarePlansByFacilityRef, ListCarePlansByFacilityVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `ListCarePlansByFacility` query requires an argument of type `ListCarePlansByFacilityVariables`:
+const listCarePlansByFacilityVars: ListCarePlansByFacilityVariables = {
+  facilityId: ..., 
+};
+
+// Call the `listCarePlansByFacilityRef()` function to get a reference to the query.
+const ref = listCarePlansByFacilityRef(listCarePlansByFacilityVars);
+// Variables can be defined inline as well.
+const ref = listCarePlansByFacilityRef({ facilityId: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = listCarePlansByFacilityRef(dataConnect, listCarePlansByFacilityVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.carePlans);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlans);
+});
+```
+
+## GetCarePlan
+You can execute the `GetCarePlan` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface GetCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+}
+export const getCarePlanRef: GetCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface GetCarePlanRef {
+  ...
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+}
+export const getCarePlanRef: GetCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getCarePlanRef:
+```typescript
+const name = getCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetCarePlanVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetCarePlan` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetCarePlanData {
+  carePlan?: {
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key;
+}
+```
+### Using `GetCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getCarePlan, GetCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`:
+const getCarePlanVars: GetCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `getCarePlan()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getCarePlan(getCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await getCarePlan({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getCarePlan(dataConnect, getCarePlanVars);
+
+console.log(data.carePlan);
+
+// Or, you can use the `Promise` API.
+getCarePlan(getCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan);
+});
+```
+
+### Using `GetCarePlan`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getCarePlanRef, GetCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetCarePlan` query requires an argument of type `GetCarePlanVariables`:
+const getCarePlanVars: GetCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `getCarePlanRef()` function to get a reference to the query.
+const ref = getCarePlanRef(getCarePlanVars);
+// Variables can be defined inline as well.
+const ref = getCarePlanRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getCarePlanRef(dataConnect, getCarePlanVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.carePlan);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan);
+});
+```
+
+## ListGoalTemplates
+You can execute the `ListGoalTemplates` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+
+interface ListGoalTemplatesRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
+
+interface ListGoalTemplatesRef {
+  ...
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the listGoalTemplatesRef:
+```typescript
+const name = listGoalTemplatesRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `ListGoalTemplates` query has no variables.
+### Return Type
+Recall that executing the `ListGoalTemplates` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `ListGoalTemplatesData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface ListGoalTemplatesData {
+  goalTemplates: ({
+    id: UUIDString;
+    supportType: string;
+    goalType: string;
+    content: string;
+    sortOrder?: number | null;
+  } & GoalTemplate_Key)[];
+}
+```
+### Using `ListGoalTemplates`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, listGoalTemplates } from '@sanwa-houkai-app/dataconnect';
+
+
+// Call the `listGoalTemplates()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await listGoalTemplates();
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await listGoalTemplates(dataConnect);
+
+console.log(data.goalTemplates);
+
+// Or, you can use the `Promise` API.
+listGoalTemplates().then((response) => {
+  const data = response.data;
+  console.log(data.goalTemplates);
+});
+```
+
+### Using `ListGoalTemplates`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, listGoalTemplatesRef } from '@sanwa-houkai-app/dataconnect';
+
+
+// Call the `listGoalTemplatesRef()` function to get a reference to the query.
+const ref = listGoalTemplatesRef();
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = listGoalTemplatesRef(dataConnect);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.goalTemplates);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.goalTemplates);
+});
+```
+
 # Mutations
 
 There are two ways to execute a Data Connect Mutation using the generated Web SDK:
@@ -3834,6 +4192,242 @@ console.log(data.carePlan_insert);
 executeMutation(ref).then((response) => {
   const data = response.data;
   console.log(data.carePlan_insert);
+});
+```
+
+## UpdateCarePlan
+You can execute the `UpdateCarePlan` mutation using the following action shortcut function, or by calling `executeMutation()` after calling the following `MutationRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+updateCarePlan(vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `MutationRef` function.
+```typescript
+updateCarePlan(dc: DataConnect, vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  ...
+  (dc: DataConnect, vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the updateCarePlanRef:
+```typescript
+const name = updateCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface UpdateCarePlanVariables {
+  id: UUIDString;
+  currentSituation?: string | null;
+  familyWishes?: string | null;
+  mainSupport?: string | null;
+  longTermGoals?: unknown | null;
+  shortTermGoals?: unknown | null;
+  pdfUrl?: string | null;
+}
+```
+### Return Type
+Recall that executing the `UpdateCarePlan` mutation returns a `MutationPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `UpdateCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface UpdateCarePlanData {
+  carePlan_update?: CarePlan_Key | null;
+}
+```
+### Using `UpdateCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, updateCarePlan, UpdateCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`:
+const updateCarePlanVars: UpdateCarePlanVariables = {
+  id: ..., 
+  currentSituation: ..., // optional
+  familyWishes: ..., // optional
+  mainSupport: ..., // optional
+  longTermGoals: ..., // optional
+  shortTermGoals: ..., // optional
+  pdfUrl: ..., // optional
+};
+
+// Call the `updateCarePlan()` function to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await updateCarePlan(updateCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await updateCarePlan({ id: ..., currentSituation: ..., familyWishes: ..., mainSupport: ..., longTermGoals: ..., shortTermGoals: ..., pdfUrl: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await updateCarePlan(dataConnect, updateCarePlanVars);
+
+console.log(data.carePlan_update);
+
+// Or, you can use the `Promise` API.
+updateCarePlan(updateCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_update);
+});
+```
+
+### Using `UpdateCarePlan`'s `MutationRef` function
+
+```typescript
+import { getDataConnect, executeMutation } from 'firebase/data-connect';
+import { connectorConfig, updateCarePlanRef, UpdateCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `UpdateCarePlan` mutation requires an argument of type `UpdateCarePlanVariables`:
+const updateCarePlanVars: UpdateCarePlanVariables = {
+  id: ..., 
+  currentSituation: ..., // optional
+  familyWishes: ..., // optional
+  mainSupport: ..., // optional
+  longTermGoals: ..., // optional
+  shortTermGoals: ..., // optional
+  pdfUrl: ..., // optional
+};
+
+// Call the `updateCarePlanRef()` function to get a reference to the mutation.
+const ref = updateCarePlanRef(updateCarePlanVars);
+// Variables can be defined inline as well.
+const ref = updateCarePlanRef({ id: ..., currentSituation: ..., familyWishes: ..., mainSupport: ..., longTermGoals: ..., shortTermGoals: ..., pdfUrl: ..., });
+
+// You can also pass in a `DataConnect` instance to the `MutationRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = updateCarePlanRef(dataConnect, updateCarePlanVars);
+
+// Call `executeMutation()` on the reference to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeMutation(ref);
+
+console.log(data.carePlan_update);
+
+// Or, you can use the `Promise` API.
+executeMutation(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_update);
+});
+```
+
+## DeleteCarePlan
+You can execute the `DeleteCarePlan` mutation using the following action shortcut function, or by calling `executeMutation()` after calling the following `MutationRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+deleteCarePlan(vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `MutationRef` function.
+```typescript
+deleteCarePlan(dc: DataConnect, vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  ...
+  (dc: DataConnect, vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the deleteCarePlanRef:
+```typescript
+const name = deleteCarePlanRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface DeleteCarePlanVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `DeleteCarePlan` mutation returns a `MutationPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `DeleteCarePlanData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface DeleteCarePlanData {
+  carePlan_delete?: CarePlan_Key | null;
+}
+```
+### Using `DeleteCarePlan`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, deleteCarePlan, DeleteCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`:
+const deleteCarePlanVars: DeleteCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `deleteCarePlan()` function to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await deleteCarePlan(deleteCarePlanVars);
+// Variables can be defined inline as well.
+const { data } = await deleteCarePlan({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await deleteCarePlan(dataConnect, deleteCarePlanVars);
+
+console.log(data.carePlan_delete);
+
+// Or, you can use the `Promise` API.
+deleteCarePlan(deleteCarePlanVars).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_delete);
+});
+```
+
+### Using `DeleteCarePlan`'s `MutationRef` function
+
+```typescript
+import { getDataConnect, executeMutation } from 'firebase/data-connect';
+import { connectorConfig, deleteCarePlanRef, DeleteCarePlanVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `DeleteCarePlan` mutation requires an argument of type `DeleteCarePlanVariables`:
+const deleteCarePlanVars: DeleteCarePlanVariables = {
+  id: ..., 
+};
+
+// Call the `deleteCarePlanRef()` function to get a reference to the mutation.
+const ref = deleteCarePlanRef(deleteCarePlanVars);
+// Variables can be defined inline as well.
+const ref = deleteCarePlanRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `MutationRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = deleteCarePlanRef(dataConnect, deleteCarePlanVars);
+
+// Call `executeMutation()` on the reference to execute the mutation.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeMutation(ref);
+
+console.log(data.carePlan_delete);
+
+// Or, you can use the `Promise` API.
+executeMutation(ref).then((response) => {
+  const data = response.data;
+  console.log(data.carePlan_delete);
 });
 ```
 

--- a/web/src/generated/dataconnect/esm/index.esm.js
+++ b/web/src/generated/dataconnect/esm/index.esm.js
@@ -160,6 +160,28 @@ export function createCarePlan(dcOrVars, vars) {
   return executeMutation(createCarePlanRef(dcOrVars, vars));
 }
 
+export const updateCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'UpdateCarePlan', inputVars);
+}
+updateCarePlanRef.operationName = 'UpdateCarePlan';
+
+export function updateCarePlan(dcOrVars, vars) {
+  return executeMutation(updateCarePlanRef(dcOrVars, vars));
+}
+
+export const deleteCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'DeleteCarePlan', inputVars);
+}
+deleteCarePlanRef.operationName = 'DeleteCarePlan';
+
+export function deleteCarePlan(dcOrVars, vars) {
+  return executeMutation(deleteCarePlanRef(dcOrVars, vars));
+}
+
 export const seedCareLevelRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -400,5 +422,38 @@ listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
 
 export function listCarePlansByClient(dcOrVars, vars) {
   return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+}
+
+export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+
+export function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+}
+
+export const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+
+export function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+}
+
+export const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+
+export function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
 }
 

--- a/web/src/generated/dataconnect/index.cjs.js
+++ b/web/src/generated/dataconnect/index.cjs.js
@@ -175,6 +175,30 @@ exports.createCarePlan = function createCarePlan(dcOrVars, vars) {
   return executeMutation(createCarePlanRef(dcOrVars, vars));
 };
 
+const updateCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'UpdateCarePlan', inputVars);
+}
+updateCarePlanRef.operationName = 'UpdateCarePlan';
+exports.updateCarePlanRef = updateCarePlanRef;
+
+exports.updateCarePlan = function updateCarePlan(dcOrVars, vars) {
+  return executeMutation(updateCarePlanRef(dcOrVars, vars));
+};
+
+const deleteCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return mutationRef(dcInstance, 'DeleteCarePlan', inputVars);
+}
+deleteCarePlanRef.operationName = 'DeleteCarePlan';
+exports.deleteCarePlanRef = deleteCarePlanRef;
+
+exports.deleteCarePlan = function deleteCarePlan(dcOrVars, vars) {
+  return executeMutation(deleteCarePlanRef(dcOrVars, vars));
+};
+
 const seedCareLevelRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -437,4 +461,40 @@ exports.listCarePlansByClientRef = listCarePlansByClientRef;
 
 exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
   return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+};
+
+const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
+
+exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+};
+
+const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+exports.getCarePlanRef = getCarePlanRef;
+
+exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+};
+
+const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+exports.listGoalTemplatesRef = listGoalTemplatesRef;
+
+exports.listGoalTemplates = function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
 };

--- a/web/src/generated/dataconnect/index.d.ts
+++ b/web/src/generated/dataconnect/index.d.ts
@@ -178,6 +178,14 @@ export interface CreateVisitRecordVariables {
   attachments?: string[] | null;
 }
 
+export interface DeleteCarePlanData {
+  carePlan_delete?: CarePlan_Key | null;
+}
+
+export interface DeleteCarePlanVariables {
+  id: UUIDString;
+}
+
 export interface DeleteClientData {
   client_update?: Client_Key | null;
 }
@@ -205,6 +213,35 @@ export interface DeleteVisitRecordVariables {
 export interface Facility_Key {
   id: UUIDString;
   __typename?: 'Facility_Key';
+}
+
+export interface GetCarePlanData {
+  carePlan?: {
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key;
+}
+
+export interface GetCarePlanVariables {
+  id: UUIDString;
 }
 
 export interface GetClientData {
@@ -329,6 +366,31 @@ export interface ListCarePlansByClientVariables {
   clientId: UUIDString;
 }
 
+export interface ListCarePlansByFacilityData {
+  carePlans: ({
+    id: UUIDString;
+    currentSituation?: string | null;
+    familyWishes?: string | null;
+    mainSupport?: string | null;
+    longTermGoals?: unknown | null;
+    shortTermGoals?: unknown | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & CarePlan_Key)[];
+}
+
+export interface ListCarePlansByFacilityVariables {
+  facilityId: UUIDString;
+}
+
 export interface ListClientsData {
   clients: ({
     id: UUIDString;
@@ -346,6 +408,16 @@ export interface ListClientsData {
 
 export interface ListClientsVariables {
   facilityId: UUIDString;
+}
+
+export interface ListGoalTemplatesData {
+  goalTemplates: ({
+    id: UUIDString;
+    supportType: string;
+    goalType: string;
+    content: string;
+    sortOrder?: number | null;
+  } & GoalTemplate_Key)[];
 }
 
 export interface ListReportsByClientData {
@@ -591,6 +663,20 @@ export interface ServiceType_Key {
 export interface Staff_Key {
   id: UUIDString;
   __typename?: 'Staff_Key';
+}
+
+export interface UpdateCarePlanData {
+  carePlan_update?: CarePlan_Key | null;
+}
+
+export interface UpdateCarePlanVariables {
+  id: UUIDString;
+  currentSituation?: string | null;
+  familyWishes?: string | null;
+  mainSupport?: string | null;
+  longTermGoals?: unknown | null;
+  shortTermGoals?: unknown | null;
+  pdfUrl?: string | null;
 }
 
 export interface UpdateClientData {
@@ -840,6 +926,30 @@ export const createCarePlanRef: CreateCarePlanRef;
 
 export function createCarePlan(vars: CreateCarePlanVariables): MutationPromise<CreateCarePlanData, CreateCarePlanVariables>;
 export function createCarePlan(dc: DataConnect, vars: CreateCarePlanVariables): MutationPromise<CreateCarePlanData, CreateCarePlanVariables>;
+
+interface UpdateCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: UpdateCarePlanVariables): MutationRef<UpdateCarePlanData, UpdateCarePlanVariables>;
+  operationName: string;
+}
+export const updateCarePlanRef: UpdateCarePlanRef;
+
+export function updateCarePlan(vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+export function updateCarePlan(dc: DataConnect, vars: UpdateCarePlanVariables): MutationPromise<UpdateCarePlanData, UpdateCarePlanVariables>;
+
+interface DeleteCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: DeleteCarePlanVariables): MutationRef<DeleteCarePlanData, DeleteCarePlanVariables>;
+  operationName: string;
+}
+export const deleteCarePlanRef: DeleteCarePlanRef;
+
+export function deleteCarePlan(vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
+export function deleteCarePlan(dc: DataConnect, vars: DeleteCarePlanVariables): MutationPromise<DeleteCarePlanData, DeleteCarePlanVariables>;
 
 interface SeedCareLevelRef {
   /* Allow users to create refs without passing in DataConnect */
@@ -1104,4 +1214,40 @@ export const listCarePlansByClientRef: ListCarePlansByClientRef;
 
 export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
 export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+
+interface ListCarePlansByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  operationName: string;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+
+export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface GetCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  operationName: string;
+}
+export const getCarePlanRef: GetCarePlanRef;
+
+export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface ListGoalTemplatesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+  operationName: string;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+
+export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
 


### PR DESCRIPTION
## Summary
- 訪問介護計画書PDF生成機能を追加
- Data Connectクエリ・ミューテーション追加（ListCarePlansByFacility, GetCarePlan, UpdateCarePlan, DeleteCarePlan等）
- generateCarePlan Cloud Function実装（PostgreSQL接続、pdfkit、Cloud Storage）
- Web計画書管理画面実装（一覧テーブル、作成/編集ダイアログ、長期/短期目標入力）

## Test plan
- [ ] Web管理画面で「計画書」メニューが表示されることを確認
- [ ] 計画書作成ダイアログで利用者を選択し、各項目を入力
- [ ] PDF生成後、自動的にダウンロードされることを確認
- [ ] 生成されたPDFの内容（利用者情報、目標等）が正しいことを確認
- [ ] 既存の計画書を編集して更新できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)