### PR TITLE
Add recurring schedule feature

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -31,7 +31,8 @@
         "react-native-gesture-handler": "~2.28.0",
         "react-native-paper": "^5.14.5",
         "react-native-safe-area-context": "^5.6.2",
-        "react-native-screens": "~4.16.0"
+        "react-native-screens": "~4.16.0",
+        "rrule": "^2.8.1"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -9237,6 +9238,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/safe-buffer": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -32,7 +32,8 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-paper": "^5.14.5",
     "react-native-safe-area-context": "^5.6.2",
-    "react-native-screens": "~4.16.0"
+    "react-native-screens": "~4.16.0",
+    "rrule": "^2.8.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,7 +26,8 @@
         "firebase": "^12.7.0",
         "next": "16.1.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "rrule": "^2.8.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -7110,6 +7111,15 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/run-parallel": {

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,8 @@
     "firebase": "^12.7.0",
     "next": "16.1.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "rrule": "^2.8.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- 繰り返し予定機能をWeb/モバイル両方に実装
- rruleライブラリを使用して繰り返しルールを生成
- 予定作成時に繰り返しパターンを選択可能

## 機能詳細
### 繰り返しパターン
- なし（単発）
- 毎日
- 毎週（曜日選択可能）
- 隔週（曜日選択可能）
- 毎月

### 終了条件
- 回数指定（1〜52回）
- 終了日指定

### データ構造
- `recurrence_rule`: iCal RRULE形式（例: `FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10`）
- `recurrence_id`: 繰り返しシリーズを識別するUUID

## 変更ファイル
- `web/src/app/schedule/page.tsx`: Web版繰り返し設定UI
- `mobile/src/screens/schedule/ScheduleFormScreen.tsx`: モバイル版繰り返し設定UI
- `web/package.json`, `mobile/package.json`: rruleパッケージ追加

## Test plan
- [ ] Web: 新規予定作成で繰り返しパターンを選択
- [ ] Web: 毎週の場合、曜日選択が表示される
- [ ] Web: 終了条件（回数/日付）を選択できる
- [ ] Web: 繰り返し予定が一括作成される
- [ ] Mobile: 新規予定作成で繰り返しパターンを選択
- [ ] Mobile: 毎週の場合、曜日選択が表示される
- [ ] Mobile: 終了条件（回数/日付）を選択できる
- [ ] Mobile: 繰り返し予定が一括作成される
- [ ] 編集時は単一予定のみ更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)