### PR TITLE
Add recurring schedule edit/delete scope selection

### DIFF
--- a/dataconnect/connector/queries.gql
+++ b/dataconnect/connector/queries.gql
@@ -137,6 +137,38 @@ query ListSchedulesByDateRange(
     endTime
     status
     notes
+    recurrenceRule
+    recurrenceId
+    client {
+      id
+      name
+    }
+    staff {
+      id
+      name
+    }
+    serviceType {
+      id
+      name
+      category
+      color
+    }
+  }
+}
+
+query GetSchedulesByRecurrenceId($recurrenceId: UUID!) @auth(level: USER) {
+  schedules(
+    where: { recurrenceId: { eq: $recurrenceId } }
+    orderBy: [{ scheduledDate: ASC }, { startTime: ASC }]
+  ) {
+    id
+    scheduledDate
+    startTime
+    endTime
+    status
+    notes
+    recurrenceRule
+    recurrenceId
     client {
       id
       name

--- a/mobile/src/generated/dataconnect/README.md
+++ b/mobile/src/generated/dataconnect/README.md
@@ -17,6 +17,7 @@ This README will guide you through the process of using the generated JavaScript
   - [*ListClients*](#listclients)
   - [*GetClient*](#getclient)
   - [*ListSchedulesByDateRange*](#listschedulesbydaterange)
+  - [*GetSchedulesByRecurrenceId*](#getschedulesbyrecurrenceid)
   - [*ListSchedulesByStaff*](#listschedulesbystaff)
   - [*ListVisitRecordsByClient*](#listvisitrecordsbyclient)
   - [*ListVisitRecordsByDateRange*](#listvisitrecordsbydaterange)
@@ -1053,6 +1054,8 @@ export interface ListSchedulesByDateRangeData {
     endTime: string;
     status?: string | null;
     notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
     client: {
       id: UUIDString;
       name: string;
@@ -1123,6 +1126,138 @@ const ref = listSchedulesByDateRangeRef({ facilityId: ..., startDate: ..., endDa
 // You can also pass in a `DataConnect` instance to the `QueryRef` function.
 const dataConnect = getDataConnect(connectorConfig);
 const ref = listSchedulesByDateRangeRef(dataConnect, listSchedulesByDateRangeVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.schedules);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.schedules);
+});
+```
+
+## GetSchedulesByRecurrenceId
+You can execute the `GetSchedulesByRecurrenceId` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  ...
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getSchedulesByRecurrenceIdRef:
+```typescript
+const name = getSchedulesByRecurrenceIdRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetSchedulesByRecurrenceIdVariables {
+  recurrenceId: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetSchedulesByRecurrenceId` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetSchedulesByRecurrenceIdData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetSchedulesByRecurrenceIdData {
+  schedules: ({
+    id: UUIDString;
+    scheduledDate: DateString;
+    startTime: string;
+    endTime: string;
+    status?: string | null;
+    notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+        serviceType?: {
+          id: UUIDString;
+          name: string;
+          category: string;
+          color?: string | null;
+        } & ServiceType_Key;
+  } & Schedule_Key)[];
+}
+```
+### Using `GetSchedulesByRecurrenceId`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getSchedulesByRecurrenceId, GetSchedulesByRecurrenceIdVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`:
+const getSchedulesByRecurrenceIdVars: GetSchedulesByRecurrenceIdVariables = {
+  recurrenceId: ..., 
+};
+
+// Call the `getSchedulesByRecurrenceId()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getSchedulesByRecurrenceId(getSchedulesByRecurrenceIdVars);
+// Variables can be defined inline as well.
+const { data } = await getSchedulesByRecurrenceId({ recurrenceId: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getSchedulesByRecurrenceId(dataConnect, getSchedulesByRecurrenceIdVars);
+
+console.log(data.schedules);
+
+// Or, you can use the `Promise` API.
+getSchedulesByRecurrenceId(getSchedulesByRecurrenceIdVars).then((response) => {
+  const data = response.data;
+  console.log(data.schedules);
+});
+```
+
+### Using `GetSchedulesByRecurrenceId`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getSchedulesByRecurrenceIdRef, GetSchedulesByRecurrenceIdVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`:
+const getSchedulesByRecurrenceIdVars: GetSchedulesByRecurrenceIdVariables = {
+  recurrenceId: ..., 
+};
+
+// Call the `getSchedulesByRecurrenceIdRef()` function to get a reference to the query.
+const ref = getSchedulesByRecurrenceIdRef(getSchedulesByRecurrenceIdVars);
+// Variables can be defined inline as well.
+const ref = getSchedulesByRecurrenceIdRef({ recurrenceId: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getSchedulesByRecurrenceIdRef(dataConnect, getSchedulesByRecurrenceIdVars);
 
 // Call `executeQuery()` on the reference to execute the query.
 // You can use the `await` keyword to wait for the promise to resolve.

--- a/mobile/src/generated/dataconnect/esm/index.esm.js
+++ b/mobile/src/generated/dataconnect/esm/index.esm.js
@@ -347,6 +347,17 @@ export function listSchedulesByDateRange(dcOrVars, vars) {
   return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
 }
 
+export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+
+export function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+}
+
 export const listSchedulesByStaffRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();

--- a/mobile/src/generated/dataconnect/index.cjs.js
+++ b/mobile/src/generated/dataconnect/index.cjs.js
@@ -379,6 +379,18 @@ exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, v
   return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
 };
 
+const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
+
+exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+};
+
 const listSchedulesByStaffRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();

--- a/mobile/src/generated/dataconnect/index.d.ts
+++ b/mobile/src/generated/dataconnect/index.d.ts
@@ -277,6 +277,37 @@ export interface GetClientVariables {
   id: UUIDString;
 }
 
+export interface GetSchedulesByRecurrenceIdData {
+  schedules: ({
+    id: UUIDString;
+    scheduledDate: DateString;
+    startTime: string;
+    endTime: string;
+    status?: string | null;
+    notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+        serviceType?: {
+          id: UUIDString;
+          name: string;
+          category: string;
+          color?: string | null;
+        } & ServiceType_Key;
+  } & Schedule_Key)[];
+}
+
+export interface GetSchedulesByRecurrenceIdVariables {
+  recurrenceId: UUIDString;
+}
+
 export interface GetStaffByFirebaseUidData {
   staffs: ({
     id: UUIDString;
@@ -469,6 +500,8 @@ export interface ListSchedulesByDateRangeData {
     endTime: string;
     status?: string | null;
     notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
     client: {
       id: UUIDString;
       name: string;
@@ -1130,6 +1163,18 @@ export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
 
 export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
 export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  operationName: string;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+
+export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
 
 interface ListSchedulesByStaffRef {
   /* Allow users to create refs without passing in DataConnect */

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -47,6 +47,7 @@ export type ScheduleStackParamList = {
       startTime: string;
       endTime: string;
       notes?: string | null;
+      recurrenceId?: string | null;
     };
     initialDate?: string;
   };

--- a/mobile/src/screens/schedule/ScheduleScreen.tsx
+++ b/mobile/src/screens/schedule/ScheduleScreen.tsx
@@ -200,6 +200,7 @@ export default function ScheduleScreen() {
         startTime: schedule.startTime,
         endTime: schedule.endTime,
         notes: schedule.notes,
+        recurrenceId: schedule.recurrenceId,
       },
     });
   };

--- a/web/src/generated/dataconnect/README.md
+++ b/web/src/generated/dataconnect/README.md
@@ -17,6 +17,7 @@ This README will guide you through the process of using the generated JavaScript
   - [*ListClients*](#listclients)
   - [*GetClient*](#getclient)
   - [*ListSchedulesByDateRange*](#listschedulesbydaterange)
+  - [*GetSchedulesByRecurrenceId*](#getschedulesbyrecurrenceid)
   - [*ListSchedulesByStaff*](#listschedulesbystaff)
   - [*ListVisitRecordsByClient*](#listvisitrecordsbyclient)
   - [*ListVisitRecordsByDateRange*](#listvisitrecordsbydaterange)
@@ -1053,6 +1054,8 @@ export interface ListSchedulesByDateRangeData {
     endTime: string;
     status?: string | null;
     notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
     client: {
       id: UUIDString;
       name: string;
@@ -1123,6 +1126,138 @@ const ref = listSchedulesByDateRangeRef({ facilityId: ..., startDate: ..., endDa
 // You can also pass in a `DataConnect` instance to the `QueryRef` function.
 const dataConnect = getDataConnect(connectorConfig);
 const ref = listSchedulesByDateRangeRef(dataConnect, listSchedulesByDateRangeVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.schedules);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.schedules);
+});
+```
+
+## GetSchedulesByRecurrenceId
+You can execute the `GetSchedulesByRecurrenceId` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  ...
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getSchedulesByRecurrenceIdRef:
+```typescript
+const name = getSchedulesByRecurrenceIdRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetSchedulesByRecurrenceIdVariables {
+  recurrenceId: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetSchedulesByRecurrenceId` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetSchedulesByRecurrenceIdData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetSchedulesByRecurrenceIdData {
+  schedules: ({
+    id: UUIDString;
+    scheduledDate: DateString;
+    startTime: string;
+    endTime: string;
+    status?: string | null;
+    notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+        serviceType?: {
+          id: UUIDString;
+          name: string;
+          category: string;
+          color?: string | null;
+        } & ServiceType_Key;
+  } & Schedule_Key)[];
+}
+```
+### Using `GetSchedulesByRecurrenceId`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getSchedulesByRecurrenceId, GetSchedulesByRecurrenceIdVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`:
+const getSchedulesByRecurrenceIdVars: GetSchedulesByRecurrenceIdVariables = {
+  recurrenceId: ..., 
+};
+
+// Call the `getSchedulesByRecurrenceId()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getSchedulesByRecurrenceId(getSchedulesByRecurrenceIdVars);
+// Variables can be defined inline as well.
+const { data } = await getSchedulesByRecurrenceId({ recurrenceId: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getSchedulesByRecurrenceId(dataConnect, getSchedulesByRecurrenceIdVars);
+
+console.log(data.schedules);
+
+// Or, you can use the `Promise` API.
+getSchedulesByRecurrenceId(getSchedulesByRecurrenceIdVars).then((response) => {
+  const data = response.data;
+  console.log(data.schedules);
+});
+```
+
+### Using `GetSchedulesByRecurrenceId`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getSchedulesByRecurrenceIdRef, GetSchedulesByRecurrenceIdVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetSchedulesByRecurrenceId` query requires an argument of type `GetSchedulesByRecurrenceIdVariables`:
+const getSchedulesByRecurrenceIdVars: GetSchedulesByRecurrenceIdVariables = {
+  recurrenceId: ..., 
+};
+
+// Call the `getSchedulesByRecurrenceIdRef()` function to get a reference to the query.
+const ref = getSchedulesByRecurrenceIdRef(getSchedulesByRecurrenceIdVars);
+// Variables can be defined inline as well.
+const ref = getSchedulesByRecurrenceIdRef({ recurrenceId: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getSchedulesByRecurrenceIdRef(dataConnect, getSchedulesByRecurrenceIdVars);
 
 // Call `executeQuery()` on the reference to execute the query.
 // You can use the `await` keyword to wait for the promise to resolve.

--- a/web/src/generated/dataconnect/esm/index.esm.js
+++ b/web/src/generated/dataconnect/esm/index.esm.js
@@ -347,6 +347,17 @@ export function listSchedulesByDateRange(dcOrVars, vars) {
   return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
 }
 
+export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+
+export function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+}
+
 export const listSchedulesByStaffRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();

--- a/web/src/generated/dataconnect/index.cjs.js
+++ b/web/src/generated/dataconnect/index.cjs.js
@@ -379,6 +379,18 @@ exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, v
   return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
 };
 
+const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
+
+exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+};
+
 const listSchedulesByStaffRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();

--- a/web/src/generated/dataconnect/index.d.ts
+++ b/web/src/generated/dataconnect/index.d.ts
@@ -277,6 +277,37 @@ export interface GetClientVariables {
   id: UUIDString;
 }
 
+export interface GetSchedulesByRecurrenceIdData {
+  schedules: ({
+    id: UUIDString;
+    scheduledDate: DateString;
+    startTime: string;
+    endTime: string;
+    status?: string | null;
+    notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
+    client: {
+      id: UUIDString;
+      name: string;
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+        serviceType?: {
+          id: UUIDString;
+          name: string;
+          category: string;
+          color?: string | null;
+        } & ServiceType_Key;
+  } & Schedule_Key)[];
+}
+
+export interface GetSchedulesByRecurrenceIdVariables {
+  recurrenceId: UUIDString;
+}
+
 export interface GetStaffByFirebaseUidData {
   staffs: ({
     id: UUIDString;
@@ -469,6 +500,8 @@ export interface ListSchedulesByDateRangeData {
     endTime: string;
     status?: string | null;
     notes?: string | null;
+    recurrenceRule?: string | null;
+    recurrenceId?: UUIDString | null;
     client: {
       id: UUIDString;
       name: string;
@@ -1130,6 +1163,18 @@ export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
 
 export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
 export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  operationName: string;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+
+export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
 
 interface ListSchedulesByStaffRef {
   /* Allow users to create refs without passing in DataConnect */


### PR DESCRIPTION
## Summary
- 繰り返し予定の編集時に「この予定のみ」「この予定以降すべて」「シリーズ全体」の選択ダイアログを追加
- 繰り返し予定の削除時に「この予定のみ」「シリーズ全体」の選択ダイアログを追加
- Web/Mobile両対応

## Changes
- **Data Connect**: GetSchedulesByRecurrenceId クエリ追加、ListSchedulesByDateRange に recurrenceId フィールド追加
- **Web**: 編集・削除時の選択ダイアログ（MUI Dialog + RadioGroup）
- **Mobile**: 編集・削除時の選択ダイアログ（React Native Paper Modal + RadioButton）

## Test plan
- [ ] Web: 繰り返し予定を編集 → 選択ダイアログが表示される
- [ ] Web: 「この予定のみ」選択 → 単一予定のみ更新される
- [ ] Web: 「シリーズ全体」選択 → 全ての関連予定が更新される
- [ ] Web: 繰り返し予定を削除 → 選択ダイアログが表示される
- [ ] Mobile: 繰り返し予定を編集 → 選択ダイアログが表示される
- [ ] Mobile: 繰り返し予定を削除 → 選択ダイアログが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)