### PR TITLE
Add mobile care plan display feature

### DIFF
--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -16,6 +16,8 @@ import ScheduleFormScreen from '../screens/schedule/ScheduleFormScreen';
 import ClientListScreen from '../screens/clients/ClientListScreen';
 import ClientDetailScreen from '../screens/clients/ClientDetailScreen';
 import SettingsScreen from '../screens/settings/SettingsScreen';
+import CarePlansScreen from '../screens/careplans/CarePlansScreen';
+import CarePlanDetailScreen from '../screens/careplans/CarePlanDetailScreen';
 
 export type RootStackParamList = {
   Login: undefined;
@@ -58,11 +60,23 @@ export type ClientStackParamList = {
   ClientDetail: { clientId: string };
 };
 
+export type SettingsStackParamList = {
+  SettingsMain: undefined;
+  CarePlansStack: undefined;
+};
+
+export type CarePlansStackParamList = {
+  CarePlansList: undefined;
+  CarePlanDetail: { carePlanId: string };
+};
+
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<MainTabParamList>();
 const RecordHistoryStack = createNativeStackNavigator<RecordHistoryStackParamList>();
 const ScheduleStack = createNativeStackNavigator<ScheduleStackParamList>();
 const ClientStack = createNativeStackNavigator<ClientStackParamList>();
+const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
+const CarePlansStack = createNativeStackNavigator<CarePlansStackParamList>();
 
 function RecordHistoryNavigator() {
   return (
@@ -88,6 +102,24 @@ function ClientNavigator() {
       <ClientStack.Screen name="ClientList" component={ClientListScreen} />
       <ClientStack.Screen name="ClientDetail" component={ClientDetailScreen} />
     </ClientStack.Navigator>
+  );
+}
+
+function CarePlansNavigator() {
+  return (
+    <CarePlansStack.Navigator screenOptions={{ headerShown: false }}>
+      <CarePlansStack.Screen name="CarePlansList" component={CarePlansScreen} />
+      <CarePlansStack.Screen name="CarePlanDetail" component={CarePlanDetailScreen} />
+    </CarePlansStack.Navigator>
+  );
+}
+
+function SettingsNavigator() {
+  return (
+    <SettingsStack.Navigator screenOptions={{ headerShown: false }}>
+      <SettingsStack.Screen name="SettingsMain" component={SettingsScreen} />
+      <SettingsStack.Screen name="CarePlansStack" component={CarePlansNavigator} />
+    </SettingsStack.Navigator>
   );
 }
 
@@ -154,7 +186,7 @@ function MainTabs() {
       />
       <Tab.Screen
         name="Settings"
-        component={SettingsScreen}
+        component={SettingsNavigator}
         options={{
           tabBarLabel: 'その他',
           tabBarIcon: ({ color, size }) => (

--- a/mobile/src/screens/careplans/CarePlanDetailScreen.tsx
+++ b/mobile/src/screens/careplans/CarePlanDetailScreen.tsx
@@ -1,0 +1,408 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, ScrollView, Linking, Alert } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  Divider,
+  IconButton,
+  Button,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { dataConnect } from '../../lib/firebase';
+import { getCarePlan, GetCarePlanData } from '@sanwa-houkai-app/dataconnect';
+import { CarePlansStackParamList } from '../../navigation/RootNavigator';
+
+type CarePlan = NonNullable<GetCarePlanData['carePlan']>;
+
+interface Goal {
+  content: string;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+type RouteProps = RouteProp<CarePlansStackParamList, 'CarePlanDetail'>;
+type NavigationProp = NativeStackNavigationProp<CarePlansStackParamList, 'CarePlanDetail'>;
+
+export default function CarePlanDetailScreen() {
+  const theme = useTheme();
+  const route = useRoute<RouteProps>();
+  const navigation = useNavigation<NavigationProp>();
+  const { carePlanId } = route.params;
+
+  const [carePlan, setCarePlan] = useState<CarePlan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchCarePlan = async () => {
+      try {
+        const result = await getCarePlan(dataConnect, { id: carePlanId });
+        if (result.data.carePlan) {
+          setCarePlan(result.data.carePlan);
+        } else {
+          setError('計画書が見つかりません');
+        }
+      } catch (err) {
+        console.error('Failed to load care plan:', err);
+        setError('計画書の読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCarePlan();
+  }, [carePlanId]);
+
+  const formatDate = (dateStr: string | null | undefined) => {
+    if (!dateStr) return '';
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const handleOpenPdf = async () => {
+    if (!carePlan?.pdfUrl) {
+      Alert.alert('エラー', 'PDFが見つかりません');
+      return;
+    }
+
+    try {
+      const supported = await Linking.canOpenURL(carePlan.pdfUrl);
+      if (supported) {
+        await Linking.openURL(carePlan.pdfUrl);
+      } else {
+        Alert.alert('エラー', 'PDFを開けません');
+      }
+    } catch (err) {
+      console.error('Failed to open PDF:', err);
+      Alert.alert('エラー', 'PDFを開けませんでした');
+    }
+  };
+
+  const parseGoals = (goalsData: unknown): Goal[] => {
+    if (!goalsData) return [];
+    try {
+      if (typeof goalsData === 'string') {
+        return JSON.parse(goalsData);
+      }
+      return goalsData as Goal[];
+    } catch {
+      return [];
+    }
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !carePlan) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.header}>
+          <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+          <Text variant="titleLarge" style={styles.headerTitle}>
+            計画書詳細
+          </Text>
+          <View style={{ width: 48 }} />
+        </View>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error || '計画書が見つかりません'}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const longTermGoals = parseGoals(carePlan.longTermGoals);
+  const shortTermGoals = parseGoals(carePlan.shortTermGoals);
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+        <Text variant="titleLarge" style={styles.headerTitle}>
+          計画書詳細
+        </Text>
+        <View style={{ width: 48 }} />
+      </View>
+
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        {/* Client Info */}
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <Text variant="titleLarge" style={styles.clientName}>
+              {carePlan.client.name}
+            </Text>
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                作成日
+              </Text>
+              <Text variant="bodyLarge" style={styles.value}>
+                {formatDate(carePlan.createdAt)}
+              </Text>
+            </View>
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                担当者
+              </Text>
+              <Chip icon="account" compact>
+                {carePlan.staff.name}
+              </Chip>
+            </View>
+          </Card.Content>
+        </Card>
+
+        {/* PDF Download */}
+        {carePlan.pdfUrl && (
+          <Button
+            mode="contained"
+            icon="file-pdf-box"
+            onPress={handleOpenPdf}
+            style={styles.pdfButton}
+          >
+            PDFを開く
+          </Button>
+        )}
+
+        {/* Current Situation */}
+        {carePlan.currentSituation && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                利用者の生活現状
+              </Text>
+              <Text variant="bodyMedium" style={styles.contentText}>
+                {carePlan.currentSituation}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Family Wishes */}
+        {carePlan.familyWishes && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                利用者及び家族の意向・希望
+              </Text>
+              <Text variant="bodyMedium" style={styles.contentText}>
+                {carePlan.familyWishes}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Main Support */}
+        {carePlan.mainSupport && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                主な支援内容
+              </Text>
+              <Text variant="bodyMedium" style={styles.contentText}>
+                {carePlan.mainSupport}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Long Term Goals */}
+        {longTermGoals.length > 0 && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                長期目標
+              </Text>
+              {longTermGoals.map((goal, index) => (
+                goal.content && (
+                  <View key={`long-${index}`} style={styles.goalItem}>
+                    <View style={styles.goalHeader}>
+                      <Chip
+                        compact
+                        style={{ backgroundColor: theme.colors.primaryContainer }}
+                        textStyle={styles.goalNumber}
+                      >
+                        {index + 1}
+                      </Chip>
+                      {(goal.startDate || goal.endDate) && (
+                        <Text variant="bodySmall" style={styles.goalPeriod}>
+                          {formatDate(goal.startDate)} - {formatDate(goal.endDate)}
+                        </Text>
+                      )}
+                    </View>
+                    <Text variant="bodyMedium" style={styles.goalContent}>
+                      {goal.content}
+                    </Text>
+                    {index < longTermGoals.length - 1 && <Divider style={styles.goalDivider} />}
+                  </View>
+                )
+              ))}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Short Term Goals */}
+        {shortTermGoals.length > 0 && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                短期目標
+              </Text>
+              {shortTermGoals.map((goal, index) => (
+                goal.content && (
+                  <View key={`short-${index}`} style={styles.goalItem}>
+                    <View style={styles.goalHeader}>
+                      <Chip
+                        compact
+                        style={{ backgroundColor: theme.colors.secondaryContainer }}
+                        textStyle={styles.goalNumber}
+                      >
+                        {index + 1}
+                      </Chip>
+                      {(goal.startDate || goal.endDate) && (
+                        <Text variant="bodySmall" style={styles.goalPeriod}>
+                          {formatDate(goal.startDate)} - {formatDate(goal.endDate)}
+                        </Text>
+                      )}
+                    </View>
+                    <Text variant="bodyMedium" style={styles.goalContent}>
+                      {goal.content}
+                    </Text>
+                    {index < shortTermGoals.length - 1 && <Divider style={styles.goalDivider} />}
+                  </View>
+                )
+              ))}
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Metadata */}
+        <View style={styles.metadata}>
+          <Text variant="bodySmall" style={styles.metadataText}>
+            作成: {new Date(carePlan.createdAt).toLocaleString('ja-JP')}
+          </Text>
+          {carePlan.updatedAt !== carePlan.createdAt && (
+            <Text variant="bodySmall" style={styles.metadataText}>
+              更新: {new Date(carePlan.updatedAt).toLocaleString('ja-JP')}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    backgroundColor: '#FFFFFF',
+  },
+  headerTitle: {
+    fontWeight: '600',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  card: {
+    marginBottom: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  clientName: {
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  label: {
+    width: 80,
+    color: '#757575',
+  },
+  value: {
+    flex: 1,
+    color: '#212121',
+  },
+  pdfButton: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  contentText: {
+    color: '#424242',
+    lineHeight: 22,
+  },
+  goalItem: {
+    marginBottom: 8,
+  },
+  goalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginBottom: 8,
+  },
+  goalNumber: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  goalPeriod: {
+    color: '#757575',
+  },
+  goalContent: {
+    color: '#424242',
+    lineHeight: 22,
+    paddingLeft: 8,
+  },
+  goalDivider: {
+    marginTop: 12,
+    marginBottom: 8,
+  },
+  metadata: {
+    marginTop: 8,
+    paddingHorizontal: 4,
+  },
+  metadataText: {
+    color: '#9E9E9E',
+    marginBottom: 4,
+  },
+});

--- a/mobile/src/screens/careplans/CarePlansScreen.tsx
+++ b/mobile/src/screens/careplans/CarePlansScreen.tsx
@@ -1,0 +1,380 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, StyleSheet, FlatList, RefreshControl, TouchableOpacity } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  IconButton,
+  Menu,
+  Divider,
+  FAB,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useStaff } from '../../hooks/useStaff';
+import { dataConnect } from '../../lib/firebase';
+import {
+  listCarePlansByFacility,
+  listClients,
+  ListCarePlansByFacilityData,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+import { CarePlansStackParamList } from '../../navigation/RootNavigator';
+
+type CarePlan = ListCarePlansByFacilityData['carePlans'][0];
+type Client = ListClientsData['clients'][0];
+
+interface Goal {
+  content: string;
+  startDate?: string | null;
+  endDate?: string | null;
+}
+
+type NavigationProp = NativeStackNavigationProp<CarePlansStackParamList, 'CarePlansList'>;
+
+export default function CarePlansScreen() {
+  const theme = useTheme();
+  const navigation = useNavigation<NavigationProp>();
+  const { facilityId, loading: staffLoading } = useStaff();
+
+  const [carePlans, setCarePlans] = useState<CarePlan[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter state
+  const [filterClientId, setFilterClientId] = useState<string | null>(null);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const [carePlansRes, clientsRes] = await Promise.all([
+        listCarePlansByFacility(dataConnect, { facilityId }),
+        listClients(dataConnect, { facilityId }),
+      ]);
+
+      setCarePlans(carePlansRes.data.carePlans);
+      setClients(clientsRes.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load care plans:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  const handleCarePlanPress = (carePlan: CarePlan) => {
+    navigation.navigate('CarePlanDetail', { carePlanId: carePlan.id });
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const filteredCarePlans = filterClientId
+    ? carePlans.filter((cp) => cp.client.id === filterClientId)
+    : carePlans;
+
+  const selectedClientName = filterClientId
+    ? clients.find((c) => c.id === filterClientId)?.name || '不明'
+    : null;
+
+  const renderCarePlan = ({ item }: { item: CarePlan }) => {
+    const longTermGoals = item.longTermGoals as Goal[] | null;
+    const shortTermGoals = item.shortTermGoals as Goal[] | null;
+    const longTermCount = longTermGoals?.filter((g) => g.content)?.length || 0;
+    const shortTermCount = shortTermGoals?.filter((g) => g.content)?.length || 0;
+
+    return (
+      <TouchableOpacity onPress={() => handleCarePlanPress(item)} activeOpacity={0.7}>
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <View style={styles.cardHeader}>
+              <Text variant="titleLarge" style={styles.clientName}>
+                {item.client.name}
+              </Text>
+              {item.pdfUrl && (
+                <Chip icon="file-pdf-box" compact textStyle={styles.chipText}>
+                  PDF
+                </Chip>
+              )}
+            </View>
+            <Text variant="bodyMedium" style={styles.supportText} numberOfLines={2}>
+              {item.mainSupport || '（主な支援内容未設定）'}
+            </Text>
+            <View style={styles.goalsContainer}>
+              <Chip
+                compact
+                textStyle={styles.chipText}
+                style={[
+                  styles.goalChip,
+                  longTermCount > 0 && { backgroundColor: theme.colors.primaryContainer },
+                ]}
+              >
+                長期目標: {longTermCount}件
+              </Chip>
+              <Chip
+                compact
+                textStyle={styles.chipText}
+                style={[
+                  styles.goalChip,
+                  shortTermCount > 0 && { backgroundColor: theme.colors.secondaryContainer },
+                ]}
+              >
+                短期目標: {shortTermCount}件
+              </Chip>
+            </View>
+            <View style={styles.cardFooter}>
+              <Text variant="bodySmall" style={styles.dateText}>
+                作成日: {formatDate(item.createdAt)}
+              </Text>
+              <Chip icon="account" compact textStyle={styles.chipText}>
+                {item.staff.name}
+              </Chip>
+            </View>
+          </Card.Content>
+        </Card>
+      </TouchableOpacity>
+    );
+  };
+
+  if (staffLoading || loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>スタッフ情報が見つかりません</Text>
+          <Text style={styles.subText}>管理者にお問い合わせください</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <IconButton
+            icon="arrow-left"
+            size={24}
+            onPress={() => navigation.goBack()}
+          />
+          <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.primary }]}>
+            訪問介護計画書
+          </Text>
+        </View>
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <IconButton
+              icon="filter-variant"
+              size={24}
+              onPress={() => setMenuVisible(true)}
+              style={filterClientId ? { backgroundColor: theme.colors.primaryContainer } : undefined}
+            />
+          }
+        >
+          <Menu.Item
+            onPress={() => {
+              setFilterClientId(null);
+              setMenuVisible(false);
+            }}
+            title="すべて表示"
+            leadingIcon={filterClientId === null ? 'check' : undefined}
+          />
+          <Divider />
+          {clients.map((client) => (
+            <Menu.Item
+              key={client.id}
+              onPress={() => {
+                setFilterClientId(client.id);
+                setMenuVisible(false);
+              }}
+              title={client.name}
+              leadingIcon={filterClientId === client.id ? 'check' : undefined}
+            />
+          ))}
+        </Menu>
+      </View>
+
+      {filterClientId && (
+        <View style={styles.filterChipContainer}>
+          <Chip
+            icon="account"
+            onClose={() => setFilterClientId(null)}
+            style={styles.filterChip}
+          >
+            {selectedClientName}
+          </Chip>
+        </View>
+      )}
+
+      <FlatList
+        data={filteredCarePlans}
+        renderItem={renderCarePlan}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>
+              {filterClientId
+                ? 'この利用者の計画書はありません'
+                : '計画書がありません'}
+            </Text>
+            <Text style={styles.emptySubText}>
+              Web管理画面から計画書を作成できます
+            </Text>
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingRight: 8,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    fontWeight: '600',
+  },
+  filterChipContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  filterChip: {
+    alignSelf: 'flex-start',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  subText: {
+    marginTop: 8,
+    color: '#757575',
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 8,
+  },
+  card: {
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  clientName: {
+    fontWeight: '600',
+    flex: 1,
+  },
+  supportText: {
+    color: '#757575',
+    marginBottom: 12,
+  },
+  goalsContainer: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 12,
+  },
+  goalChip: {
+    backgroundColor: '#E0E0E0',
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  dateText: {
+    color: '#9E9E9E',
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#757575',
+  },
+  emptySubText: {
+    marginTop: 8,
+    fontSize: 14,
+    color: '#9E9E9E',
+  },
+});

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -2,14 +2,24 @@ import React from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
 import { Text, useTheme, List, Avatar, Button, Divider } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useAuth } from '../../contexts/AuthContext';
+import { SettingsStackParamList } from '../../navigation/RootNavigator';
+
+type NavigationProp = NativeStackNavigationProp<SettingsStackParamList, 'SettingsMain'>;
 
 export default function SettingsScreen() {
   const theme = useTheme();
+  const navigation = useNavigation<NavigationProp>();
   const { user, signOut } = useAuth();
 
   const handleLogout = async () => {
     await signOut();
+  };
+
+  const handleCarePlansPress = () => {
+    navigation.navigate('CarePlansStack');
   };
 
   return (
@@ -44,6 +54,7 @@ export default function SettingsScreen() {
             description="報告書・計画書の出力"
             left={(props) => <List.Icon {...props} icon="file-document-outline" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
+            onPress={handleCarePlansPress}
           />
           <List.Item
             title="支援者管理"


### PR DESCRIPTION
## Summary
- モバイルアプリに訪問介護計画書の表示機能を追加
- 計画書一覧画面（利用者フィルター対応）
- 計画書詳細画面（PDF表示機能付き）
- 設定画面の「帳票一覧」から遷移可能

## Changes
- `mobile/src/screens/careplans/CarePlansScreen.tsx` - 計画書一覧画面
- `mobile/src/screens/careplans/CarePlanDetailScreen.tsx` - 計画書詳細画面
- `mobile/src/navigation/RootNavigator.tsx` - ナビゲーション追加
- `mobile/src/screens/settings/SettingsScreen.tsx` - 帳票一覧へのリンク追加

## Test plan
- [ ] 設定画面から「帳票一覧」をタップして計画書一覧画面へ遷移
- [ ] 計画書一覧が正しく表示される
- [ ] 利用者フィルターが機能する
- [ ] 計画書をタップして詳細画面へ遷移
- [ ] 「PDFを開く」ボタンでPDFが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)