### PR TITLE
Add visual indicator for recurring schedules

### DIFF
--- a/mobile/src/screens/schedule/ScheduleScreen.tsx
+++ b/mobile/src/screens/schedule/ScheduleScreen.tsx
@@ -145,10 +145,12 @@ export default function ScheduleScreen() {
       const dateStr = schedule.scheduledDate;
       const startDateTime = dayjs(`${dateStr}T${schedule.startTime}`).toDate();
       const endDateTime = dayjs(`${dateStr}T${schedule.endTime}`).toDate();
+      const isRecurring = !!schedule.recurrenceId;
+      const recurringMark = isRecurring ? '🔄 ' : '';
 
       return {
         id: schedule.id,
-        title: `${schedule.client.name}${schedule.serviceType ? `\n${schedule.serviceType.name}` : ''}`,
+        title: `${recurringMark}${schedule.client.name}${schedule.serviceType ? `\n${schedule.serviceType.name}` : ''}`,
         start: startDateTime,
         end: endDateTime,
         color: getServiceColor(schedule.serviceType?.category),
@@ -398,6 +400,16 @@ export default function ScheduleScreen() {
                 </Chip>
               </View>
 
+              {selectedSchedule.recurrenceId && (
+                <View style={styles.detailRow}>
+                  <Text style={styles.detailLabel}>繰り返し</Text>
+                  <View style={styles.recurringRow}>
+                    <Text style={styles.recurringIcon}>🔄</Text>
+                    <Text style={styles.detailValue}>繰り返し予定</Text>
+                  </View>
+                </View>
+              )}
+
               {selectedSchedule.notes && (
                 <View style={styles.detailRow}>
                   <Text style={styles.detailLabel}>メモ</Text>
@@ -527,6 +539,14 @@ const styles = StyleSheet.create({
   },
   statusChip: {
     alignSelf: 'flex-start',
+  },
+  recurringRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  recurringIcon: {
+    fontSize: 16,
+    marginRight: 4,
   },
   modalActions: {
     flexDirection: 'row',

--- a/web/src/app/schedule/page.tsx
+++ b/web/src/app/schedule/page.tsx
@@ -41,10 +41,10 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import interactionPlugin from '@fullcalendar/interaction';
-import { EventClickArg, DateSelectArg, EventDropArg } from '@fullcalendar/core';
+import { EventClickArg, DateSelectArg, EventDropArg, EventContentArg } from '@fullcalendar/core';
 import { format, parse, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addDays } from 'date-fns';
 import { ja } from 'date-fns/locale';
-import { RRule, Weekday, Options } from 'rrule';
+import { RRule, Options } from 'rrule';
 import { MainLayout } from '@/components/layout';
 import { useStaff } from '@/hooks/useStaff';
 import { useScheduleRealtime } from '@/hooks/useScheduleRealtime';
@@ -79,6 +79,7 @@ interface CalendarEvent {
   textColor: string;
   extendedProps: {
     schedule: Schedule;
+    isRecurring: boolean;
   };
 }
 
@@ -267,6 +268,7 @@ export default function SchedulePage() {
     return schedules.map((schedule) => {
       const color = getServiceColor(schedule.serviceType?.category);
       const dateStr = schedule.scheduledDate;
+      const isRecurring = !!schedule.recurrenceId;
 
       return {
         id: schedule.id,
@@ -276,7 +278,7 @@ export default function SchedulePage() {
         backgroundColor: color,
         borderColor: color,
         textColor: '#ffffff',
-        extendedProps: { schedule },
+        extendedProps: { schedule, isRecurring },
       };
     });
   }, [schedules]);
@@ -848,6 +850,24 @@ export default function SchedulePage() {
                 minute: '2-digit',
                 hour12: false,
               }}
+              eventContent={(arg: EventContentArg) => {
+                const isRecurring = arg.event.extendedProps.isRecurring;
+                return (
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 0.5, overflow: 'hidden', width: '100%' }}>
+                    {isRecurring && (
+                      <RepeatIcon sx={{ fontSize: 14, flexShrink: 0, mt: '2px' }} />
+                    )}
+                    <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 }}>
+                      <Typography variant="caption" component="div" sx={{ fontWeight: 500, lineHeight: 1.2 }}>
+                        {arg.timeText}
+                      </Typography>
+                      <Typography variant="caption" component="div" sx={{ lineHeight: 1.2 }}>
+                        {arg.event.title}
+                      </Typography>
+                    </Box>
+                  </Box>
+                );
+              }}
             />
           </CardContent>
         </Card>
@@ -909,6 +929,15 @@ export default function SchedulePage() {
                   />
                 </Box>
               </Box>
+              {selectedSchedule.recurrenceId && (
+                <Box>
+                  <Typography variant="caption" color="text.secondary">繰り返し</Typography>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <RepeatIcon fontSize="small" color="action" />
+                    <Typography variant="body2">繰り返し予定</Typography>
+                  </Box>
+                </Box>
+              )}
               {selectedSchedule.notes && (
                 <Box>
                   <Typography variant="caption" color="text.secondary">メモ</Typography>


### PR DESCRIPTION
## Summary
- カレンダー上の繰り返し予定に視覚的な識別マークを追加
- Web: カレンダーイベントにリピートアイコン（🔄）を表示、詳細ダイアログにも表示
- Mobile: カレンダーイベントに🔄マークを表示、詳細モーダルにも表示

## Test plan
- [ ] Webでスケジュール画面を開き、繰り返し予定にリピートアイコンが表示されることを確認
- [ ] Webで繰り返し予定をクリックし、詳細ダイアログに「繰り返し予定」が表示されることを確認
- [ ] モバイルでスケジュール画面を開き、繰り返し予定に🔄マークが表示されることを確認
- [ ] モバイルで繰り返し予定をタップし、詳細モーダルに「繰り返し予定」が表示されることを確認
- [ ] 通常予定（繰り返しなし）にはマークが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)