### PR TITLE
Add mobile reports display feature

### DIFF
--- a/dataconnect/connector/queries.gql
+++ b/dataconnect/connector/queries.gql
@@ -358,6 +358,31 @@ query ListReportsByFacility($facilityId: UUID!) @auth(level: USER) {
   }
 }
 
+query GetReport($id: UUID!) @auth(level: USER) {
+  report(id: $id) {
+    id
+    targetYear
+    targetMonth
+    summary
+    aiGenerated
+    pdfGenerated
+    pdfUrl
+    createdAt
+    updatedAt
+    client {
+      id
+      name
+      careLevel {
+        name
+      }
+    }
+    staff {
+      id
+      name
+    }
+  }
+}
+
 query ListCarePlansByClient($clientId: UUID!) @auth(level: USER) {
   carePlans(
     where: { client: { id: { eq: $clientId } } }

--- a/mobile/src/generated/dataconnect/.guides/usage.md
+++ b/mobile/src/generated/dataconnect/.guides/usage.md
@@ -14,38 +14,38 @@ If a user is not using a supported framework, they can use the generated SDK dir
 Here's an example of how to use it with the first 5 operations:
 
 ```js
-import { createClient, updateClient, deleteClient, createSchedule, updateSchedule, deleteSchedule, cancelSchedule, completeSchedule, createVisitRecord, updateVisitRecord } from '@sanwa-houkai-app/dataconnect';
+import { listCareLevels, listVisitReasons, listServiceTypes, listServiceItems, getStaffByFirebaseUid, listStaff, listClients, getClient, listSchedulesByDateRange, getSchedulesByRecurrenceId } from '@sanwa-houkai-app/dataconnect';
 
 
-// Operation CreateClient:  For variables, look at type CreateClientVars in ../index.d.ts
-const { data } = await CreateClient(dataConnect, createClientVars);
+// Operation ListCareLevels: 
+const { data } = await ListCareLevels(dataConnect);
 
-// Operation UpdateClient:  For variables, look at type UpdateClientVars in ../index.d.ts
-const { data } = await UpdateClient(dataConnect, updateClientVars);
+// Operation ListVisitReasons: 
+const { data } = await ListVisitReasons(dataConnect);
 
-// Operation DeleteClient:  For variables, look at type DeleteClientVars in ../index.d.ts
-const { data } = await DeleteClient(dataConnect, deleteClientVars);
+// Operation ListServiceTypes:  For variables, look at type ListServiceTypesVars in ../index.d.ts
+const { data } = await ListServiceTypes(dataConnect, listServiceTypesVars);
 
-// Operation CreateSchedule:  For variables, look at type CreateScheduleVars in ../index.d.ts
-const { data } = await CreateSchedule(dataConnect, createScheduleVars);
+// Operation ListServiceItems:  For variables, look at type ListServiceItemsVars in ../index.d.ts
+const { data } = await ListServiceItems(dataConnect, listServiceItemsVars);
 
-// Operation UpdateSchedule:  For variables, look at type UpdateScheduleVars in ../index.d.ts
-const { data } = await UpdateSchedule(dataConnect, updateScheduleVars);
+// Operation GetStaffByFirebaseUid:  For variables, look at type GetStaffByFirebaseUidVars in ../index.d.ts
+const { data } = await GetStaffByFirebaseUid(dataConnect, getStaffByFirebaseUidVars);
 
-// Operation DeleteSchedule:  For variables, look at type DeleteScheduleVars in ../index.d.ts
-const { data } = await DeleteSchedule(dataConnect, deleteScheduleVars);
+// Operation ListStaff:  For variables, look at type ListStaffVars in ../index.d.ts
+const { data } = await ListStaff(dataConnect, listStaffVars);
 
-// Operation CancelSchedule:  For variables, look at type CancelScheduleVars in ../index.d.ts
-const { data } = await CancelSchedule(dataConnect, cancelScheduleVars);
+// Operation ListClients:  For variables, look at type ListClientsVars in ../index.d.ts
+const { data } = await ListClients(dataConnect, listClientsVars);
 
-// Operation CompleteSchedule:  For variables, look at type CompleteScheduleVars in ../index.d.ts
-const { data } = await CompleteSchedule(dataConnect, completeScheduleVars);
+// Operation GetClient:  For variables, look at type GetClientVars in ../index.d.ts
+const { data } = await GetClient(dataConnect, getClientVars);
 
-// Operation CreateVisitRecord:  For variables, look at type CreateVisitRecordVars in ../index.d.ts
-const { data } = await CreateVisitRecord(dataConnect, createVisitRecordVars);
+// Operation ListSchedulesByDateRange:  For variables, look at type ListSchedulesByDateRangeVars in ../index.d.ts
+const { data } = await ListSchedulesByDateRange(dataConnect, listSchedulesByDateRangeVars);
 
-// Operation UpdateVisitRecord:  For variables, look at type UpdateVisitRecordVars in ../index.d.ts
-const { data } = await UpdateVisitRecord(dataConnect, updateVisitRecordVars);
+// Operation GetSchedulesByRecurrenceId:  For variables, look at type GetSchedulesByRecurrenceIdVars in ../index.d.ts
+const { data } = await GetSchedulesByRecurrenceId(dataConnect, getSchedulesByRecurrenceIdVars);
 
 
 ```

--- a/mobile/src/generated/dataconnect/README.md
+++ b/mobile/src/generated/dataconnect/README.md
@@ -24,6 +24,7 @@ This README will guide you through the process of using the generated JavaScript
   - [*GetVisitRecord*](#getvisitrecord)
   - [*ListReportsByClient*](#listreportsbyclient)
   - [*ListReportsByFacility*](#listreportsbyfacility)
+  - [*GetReport*](#getreport)
   - [*ListCarePlansByClient*](#listcareplansbyclient)
   - [*ListCarePlansByFacility*](#listcareplansbyfacility)
   - [*GetCarePlan*](#getcareplan)
@@ -2045,6 +2046,136 @@ console.log(data.reports);
 executeQuery(ref).then((response) => {
   const data = response.data;
   console.log(data.reports);
+});
+```
+
+## GetReport
+You can execute the `GetReport` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getReport(vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface GetReportRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+}
+export const getReportRef: GetReportRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getReport(dc: DataConnect, vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface GetReportRef {
+  ...
+  (dc: DataConnect, vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+}
+export const getReportRef: GetReportRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getReportRef:
+```typescript
+const name = getReportRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetReport` query requires an argument of type `GetReportVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetReportVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetReport` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetReportData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetReportData {
+  report?: {
+    id: UUIDString;
+    targetYear: number;
+    targetMonth: number;
+    summary?: string | null;
+    aiGenerated?: boolean | null;
+    pdfGenerated?: boolean | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & Report_Key;
+}
+```
+### Using `GetReport`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getReport, GetReportVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetReport` query requires an argument of type `GetReportVariables`:
+const getReportVars: GetReportVariables = {
+  id: ..., 
+};
+
+// Call the `getReport()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getReport(getReportVars);
+// Variables can be defined inline as well.
+const { data } = await getReport({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getReport(dataConnect, getReportVars);
+
+console.log(data.report);
+
+// Or, you can use the `Promise` API.
+getReport(getReportVars).then((response) => {
+  const data = response.data;
+  console.log(data.report);
+});
+```
+
+### Using `GetReport`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getReportRef, GetReportVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetReport` query requires an argument of type `GetReportVariables`:
+const getReportVars: GetReportVariables = {
+  id: ..., 
+};
+
+// Call the `getReportRef()` function to get a reference to the query.
+const ref = getReportRef(getReportVars);
+// Variables can be defined inline as well.
+const ref = getReportRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getReportRef(dataConnect, getReportVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.report);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.report);
 });
 ```
 

--- a/mobile/src/generated/dataconnect/esm/index.esm.js
+++ b/mobile/src/generated/dataconnect/esm/index.esm.js
@@ -6,6 +6,237 @@ export const connectorConfig = {
   location: 'asia-northeast1'
 };
 
+export const listCareLevelsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCareLevels');
+}
+listCareLevelsRef.operationName = 'ListCareLevels';
+
+export function listCareLevels(dc) {
+  return executeQuery(listCareLevelsRef(dc));
+}
+
+export const listVisitReasonsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitReasons');
+}
+listVisitReasonsRef.operationName = 'ListVisitReasons';
+
+export function listVisitReasons(dc) {
+  return executeQuery(listVisitReasonsRef(dc));
+}
+
+export const listServiceTypesRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
+}
+listServiceTypesRef.operationName = 'ListServiceTypes';
+
+export function listServiceTypes(dcOrVars, vars) {
+  return executeQuery(listServiceTypesRef(dcOrVars, vars));
+}
+
+export const listServiceItemsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceItems', inputVars);
+}
+listServiceItemsRef.operationName = 'ListServiceItems';
+
+export function listServiceItems(dcOrVars, vars) {
+  return executeQuery(listServiceItemsRef(dcOrVars, vars));
+}
+
+export const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
+}
+getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
+
+export function getStaffByFirebaseUid(dcOrVars, vars) {
+  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
+}
+
+export const listStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListStaff', inputVars);
+}
+listStaffRef.operationName = 'ListStaff';
+
+export function listStaff(dcOrVars, vars) {
+  return executeQuery(listStaffRef(dcOrVars, vars));
+}
+
+export const listClientsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListClients', inputVars);
+}
+listClientsRef.operationName = 'ListClients';
+
+export function listClients(dcOrVars, vars) {
+  return executeQuery(listClientsRef(dcOrVars, vars));
+}
+
+export const getClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetClient', inputVars);
+}
+getClientRef.operationName = 'GetClient';
+
+export function getClient(dcOrVars, vars) {
+  return executeQuery(getClientRef(dcOrVars, vars));
+}
+
+export const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
+}
+listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
+
+export function listSchedulesByDateRange(dcOrVars, vars) {
+  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
+}
+
+export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+
+export function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+}
+
+export const listSchedulesByStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
+}
+listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
+
+export function listSchedulesByStaff(dcOrVars, vars) {
+  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
+}
+
+export const listVisitRecordsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
+}
+listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
+
+export function listVisitRecordsByClient(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
+}
+
+export const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
+}
+listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
+
+export function listVisitRecordsByDateRange(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
+}
+
+export const getVisitRecordRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
+}
+getVisitRecordRef.operationName = 'GetVisitRecord';
+
+export function getVisitRecord(dcOrVars, vars) {
+  return executeQuery(getVisitRecordRef(dcOrVars, vars));
+}
+
+export const listReportsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
+}
+listReportsByClientRef.operationName = 'ListReportsByClient';
+
+export function listReportsByClient(dcOrVars, vars) {
+  return executeQuery(listReportsByClientRef(dcOrVars, vars));
+}
+
+export const listReportsByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
+}
+listReportsByFacilityRef.operationName = 'ListReportsByFacility';
+
+export function listReportsByFacility(dcOrVars, vars) {
+  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
+}
+
+export const getReportRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetReport', inputVars);
+}
+getReportRef.operationName = 'GetReport';
+
+export function getReport(dcOrVars, vars) {
+  return executeQuery(getReportRef(dcOrVars, vars));
+}
+
+export const listCarePlansByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
+}
+listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
+
+export function listCarePlansByClient(dcOrVars, vars) {
+  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+}
+
+export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+
+export function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+}
+
+export const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+
+export function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+}
+
+export const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+
+export function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
+}
+
 export const createClientRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -246,225 +477,5 @@ createServiceItemRef.operationName = 'CreateServiceItem';
 
 export function createServiceItem(dcOrVars, vars) {
   return executeMutation(createServiceItemRef(dcOrVars, vars));
-}
-
-export const listCareLevelsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCareLevels');
-}
-listCareLevelsRef.operationName = 'ListCareLevels';
-
-export function listCareLevels(dc) {
-  return executeQuery(listCareLevelsRef(dc));
-}
-
-export const listVisitReasonsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitReasons');
-}
-listVisitReasonsRef.operationName = 'ListVisitReasons';
-
-export function listVisitReasons(dc) {
-  return executeQuery(listVisitReasonsRef(dc));
-}
-
-export const listServiceTypesRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
-}
-listServiceTypesRef.operationName = 'ListServiceTypes';
-
-export function listServiceTypes(dcOrVars, vars) {
-  return executeQuery(listServiceTypesRef(dcOrVars, vars));
-}
-
-export const listServiceItemsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceItems', inputVars);
-}
-listServiceItemsRef.operationName = 'ListServiceItems';
-
-export function listServiceItems(dcOrVars, vars) {
-  return executeQuery(listServiceItemsRef(dcOrVars, vars));
-}
-
-export const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
-}
-getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
-
-export function getStaffByFirebaseUid(dcOrVars, vars) {
-  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
-}
-
-export const listStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListStaff', inputVars);
-}
-listStaffRef.operationName = 'ListStaff';
-
-export function listStaff(dcOrVars, vars) {
-  return executeQuery(listStaffRef(dcOrVars, vars));
-}
-
-export const listClientsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListClients', inputVars);
-}
-listClientsRef.operationName = 'ListClients';
-
-export function listClients(dcOrVars, vars) {
-  return executeQuery(listClientsRef(dcOrVars, vars));
-}
-
-export const getClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetClient', inputVars);
-}
-getClientRef.operationName = 'GetClient';
-
-export function getClient(dcOrVars, vars) {
-  return executeQuery(getClientRef(dcOrVars, vars));
-}
-
-export const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
-}
-listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
-
-export function listSchedulesByDateRange(dcOrVars, vars) {
-  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
-}
-
-export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
-}
-getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
-
-export function getSchedulesByRecurrenceId(dcOrVars, vars) {
-  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
-}
-
-export const listSchedulesByStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
-}
-listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
-
-export function listSchedulesByStaff(dcOrVars, vars) {
-  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
-}
-
-export const listVisitRecordsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
-}
-listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
-
-export function listVisitRecordsByClient(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
-}
-
-export const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
-}
-listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
-
-export function listVisitRecordsByDateRange(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
-}
-
-export const getVisitRecordRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
-}
-getVisitRecordRef.operationName = 'GetVisitRecord';
-
-export function getVisitRecord(dcOrVars, vars) {
-  return executeQuery(getVisitRecordRef(dcOrVars, vars));
-}
-
-export const listReportsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
-}
-listReportsByClientRef.operationName = 'ListReportsByClient';
-
-export function listReportsByClient(dcOrVars, vars) {
-  return executeQuery(listReportsByClientRef(dcOrVars, vars));
-}
-
-export const listReportsByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
-}
-listReportsByFacilityRef.operationName = 'ListReportsByFacility';
-
-export function listReportsByFacility(dcOrVars, vars) {
-  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
-}
-
-export const listCarePlansByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
-}
-listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
-
-export function listCarePlansByClient(dcOrVars, vars) {
-  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
-}
-
-export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
-}
-listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
-
-export function listCarePlansByFacility(dcOrVars, vars) {
-  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
-}
-
-export const getCarePlanRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetCarePlan', inputVars);
-}
-getCarePlanRef.operationName = 'GetCarePlan';
-
-export function getCarePlan(dcOrVars, vars) {
-  return executeQuery(getCarePlanRef(dcOrVars, vars));
-}
-
-export const listGoalTemplatesRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListGoalTemplates');
-}
-listGoalTemplatesRef.operationName = 'ListGoalTemplates';
-
-export function listGoalTemplates(dc) {
-  return executeQuery(listGoalTemplatesRef(dc));
 }
 

--- a/mobile/src/generated/dataconnect/index.cjs.js
+++ b/mobile/src/generated/dataconnect/index.cjs.js
@@ -7,6 +7,258 @@ const connectorConfig = {
 };
 exports.connectorConfig = connectorConfig;
 
+const listCareLevelsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCareLevels');
+}
+listCareLevelsRef.operationName = 'ListCareLevels';
+exports.listCareLevelsRef = listCareLevelsRef;
+
+exports.listCareLevels = function listCareLevels(dc) {
+  return executeQuery(listCareLevelsRef(dc));
+};
+
+const listVisitReasonsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitReasons');
+}
+listVisitReasonsRef.operationName = 'ListVisitReasons';
+exports.listVisitReasonsRef = listVisitReasonsRef;
+
+exports.listVisitReasons = function listVisitReasons(dc) {
+  return executeQuery(listVisitReasonsRef(dc));
+};
+
+const listServiceTypesRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
+}
+listServiceTypesRef.operationName = 'ListServiceTypes';
+exports.listServiceTypesRef = listServiceTypesRef;
+
+exports.listServiceTypes = function listServiceTypes(dcOrVars, vars) {
+  return executeQuery(listServiceTypesRef(dcOrVars, vars));
+};
+
+const listServiceItemsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceItems', inputVars);
+}
+listServiceItemsRef.operationName = 'ListServiceItems';
+exports.listServiceItemsRef = listServiceItemsRef;
+
+exports.listServiceItems = function listServiceItems(dcOrVars, vars) {
+  return executeQuery(listServiceItemsRef(dcOrVars, vars));
+};
+
+const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
+}
+getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
+exports.getStaffByFirebaseUidRef = getStaffByFirebaseUidRef;
+
+exports.getStaffByFirebaseUid = function getStaffByFirebaseUid(dcOrVars, vars) {
+  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
+};
+
+const listStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListStaff', inputVars);
+}
+listStaffRef.operationName = 'ListStaff';
+exports.listStaffRef = listStaffRef;
+
+exports.listStaff = function listStaff(dcOrVars, vars) {
+  return executeQuery(listStaffRef(dcOrVars, vars));
+};
+
+const listClientsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListClients', inputVars);
+}
+listClientsRef.operationName = 'ListClients';
+exports.listClientsRef = listClientsRef;
+
+exports.listClients = function listClients(dcOrVars, vars) {
+  return executeQuery(listClientsRef(dcOrVars, vars));
+};
+
+const getClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetClient', inputVars);
+}
+getClientRef.operationName = 'GetClient';
+exports.getClientRef = getClientRef;
+
+exports.getClient = function getClient(dcOrVars, vars) {
+  return executeQuery(getClientRef(dcOrVars, vars));
+};
+
+const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
+}
+listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
+exports.listSchedulesByDateRangeRef = listSchedulesByDateRangeRef;
+
+exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, vars) {
+  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
+};
+
+const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
+
+exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+};
+
+const listSchedulesByStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
+}
+listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
+exports.listSchedulesByStaffRef = listSchedulesByStaffRef;
+
+exports.listSchedulesByStaff = function listSchedulesByStaff(dcOrVars, vars) {
+  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
+};
+
+const listVisitRecordsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
+}
+listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
+exports.listVisitRecordsByClientRef = listVisitRecordsByClientRef;
+
+exports.listVisitRecordsByClient = function listVisitRecordsByClient(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
+};
+
+const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
+}
+listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
+exports.listVisitRecordsByDateRangeRef = listVisitRecordsByDateRangeRef;
+
+exports.listVisitRecordsByDateRange = function listVisitRecordsByDateRange(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
+};
+
+const getVisitRecordRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
+}
+getVisitRecordRef.operationName = 'GetVisitRecord';
+exports.getVisitRecordRef = getVisitRecordRef;
+
+exports.getVisitRecord = function getVisitRecord(dcOrVars, vars) {
+  return executeQuery(getVisitRecordRef(dcOrVars, vars));
+};
+
+const listReportsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
+}
+listReportsByClientRef.operationName = 'ListReportsByClient';
+exports.listReportsByClientRef = listReportsByClientRef;
+
+exports.listReportsByClient = function listReportsByClient(dcOrVars, vars) {
+  return executeQuery(listReportsByClientRef(dcOrVars, vars));
+};
+
+const listReportsByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
+}
+listReportsByFacilityRef.operationName = 'ListReportsByFacility';
+exports.listReportsByFacilityRef = listReportsByFacilityRef;
+
+exports.listReportsByFacility = function listReportsByFacility(dcOrVars, vars) {
+  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
+};
+
+const getReportRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetReport', inputVars);
+}
+getReportRef.operationName = 'GetReport';
+exports.getReportRef = getReportRef;
+
+exports.getReport = function getReport(dcOrVars, vars) {
+  return executeQuery(getReportRef(dcOrVars, vars));
+};
+
+const listCarePlansByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
+}
+listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
+exports.listCarePlansByClientRef = listCarePlansByClientRef;
+
+exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
+  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+};
+
+const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
+
+exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+};
+
+const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+exports.getCarePlanRef = getCarePlanRef;
+
+exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+};
+
+const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+exports.listGoalTemplatesRef = listGoalTemplatesRef;
+
+exports.listGoalTemplates = function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
+};
+
 const createClientRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -269,244 +521,4 @@ exports.createServiceItemRef = createServiceItemRef;
 
 exports.createServiceItem = function createServiceItem(dcOrVars, vars) {
   return executeMutation(createServiceItemRef(dcOrVars, vars));
-};
-
-const listCareLevelsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCareLevels');
-}
-listCareLevelsRef.operationName = 'ListCareLevels';
-exports.listCareLevelsRef = listCareLevelsRef;
-
-exports.listCareLevels = function listCareLevels(dc) {
-  return executeQuery(listCareLevelsRef(dc));
-};
-
-const listVisitReasonsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitReasons');
-}
-listVisitReasonsRef.operationName = 'ListVisitReasons';
-exports.listVisitReasonsRef = listVisitReasonsRef;
-
-exports.listVisitReasons = function listVisitReasons(dc) {
-  return executeQuery(listVisitReasonsRef(dc));
-};
-
-const listServiceTypesRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
-}
-listServiceTypesRef.operationName = 'ListServiceTypes';
-exports.listServiceTypesRef = listServiceTypesRef;
-
-exports.listServiceTypes = function listServiceTypes(dcOrVars, vars) {
-  return executeQuery(listServiceTypesRef(dcOrVars, vars));
-};
-
-const listServiceItemsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceItems', inputVars);
-}
-listServiceItemsRef.operationName = 'ListServiceItems';
-exports.listServiceItemsRef = listServiceItemsRef;
-
-exports.listServiceItems = function listServiceItems(dcOrVars, vars) {
-  return executeQuery(listServiceItemsRef(dcOrVars, vars));
-};
-
-const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
-}
-getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
-exports.getStaffByFirebaseUidRef = getStaffByFirebaseUidRef;
-
-exports.getStaffByFirebaseUid = function getStaffByFirebaseUid(dcOrVars, vars) {
-  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
-};
-
-const listStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListStaff', inputVars);
-}
-listStaffRef.operationName = 'ListStaff';
-exports.listStaffRef = listStaffRef;
-
-exports.listStaff = function listStaff(dcOrVars, vars) {
-  return executeQuery(listStaffRef(dcOrVars, vars));
-};
-
-const listClientsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListClients', inputVars);
-}
-listClientsRef.operationName = 'ListClients';
-exports.listClientsRef = listClientsRef;
-
-exports.listClients = function listClients(dcOrVars, vars) {
-  return executeQuery(listClientsRef(dcOrVars, vars));
-};
-
-const getClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetClient', inputVars);
-}
-getClientRef.operationName = 'GetClient';
-exports.getClientRef = getClientRef;
-
-exports.getClient = function getClient(dcOrVars, vars) {
-  return executeQuery(getClientRef(dcOrVars, vars));
-};
-
-const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
-}
-listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
-exports.listSchedulesByDateRangeRef = listSchedulesByDateRangeRef;
-
-exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, vars) {
-  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
-};
-
-const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
-}
-getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
-exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
-
-exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
-  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
-};
-
-const listSchedulesByStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
-}
-listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
-exports.listSchedulesByStaffRef = listSchedulesByStaffRef;
-
-exports.listSchedulesByStaff = function listSchedulesByStaff(dcOrVars, vars) {
-  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
-};
-
-const listVisitRecordsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
-}
-listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
-exports.listVisitRecordsByClientRef = listVisitRecordsByClientRef;
-
-exports.listVisitRecordsByClient = function listVisitRecordsByClient(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
-};
-
-const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
-}
-listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
-exports.listVisitRecordsByDateRangeRef = listVisitRecordsByDateRangeRef;
-
-exports.listVisitRecordsByDateRange = function listVisitRecordsByDateRange(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
-};
-
-const getVisitRecordRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
-}
-getVisitRecordRef.operationName = 'GetVisitRecord';
-exports.getVisitRecordRef = getVisitRecordRef;
-
-exports.getVisitRecord = function getVisitRecord(dcOrVars, vars) {
-  return executeQuery(getVisitRecordRef(dcOrVars, vars));
-};
-
-const listReportsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
-}
-listReportsByClientRef.operationName = 'ListReportsByClient';
-exports.listReportsByClientRef = listReportsByClientRef;
-
-exports.listReportsByClient = function listReportsByClient(dcOrVars, vars) {
-  return executeQuery(listReportsByClientRef(dcOrVars, vars));
-};
-
-const listReportsByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
-}
-listReportsByFacilityRef.operationName = 'ListReportsByFacility';
-exports.listReportsByFacilityRef = listReportsByFacilityRef;
-
-exports.listReportsByFacility = function listReportsByFacility(dcOrVars, vars) {
-  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
-};
-
-const listCarePlansByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
-}
-listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
-exports.listCarePlansByClientRef = listCarePlansByClientRef;
-
-exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
-  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
-};
-
-const listCarePlansByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
-}
-listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
-exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
-
-exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
-  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
-};
-
-const getCarePlanRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetCarePlan', inputVars);
-}
-getCarePlanRef.operationName = 'GetCarePlan';
-exports.getCarePlanRef = getCarePlanRef;
-
-exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
-  return executeQuery(getCarePlanRef(dcOrVars, vars));
-};
-
-const listGoalTemplatesRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListGoalTemplates');
-}
-listGoalTemplatesRef.operationName = 'ListGoalTemplates';
-exports.listGoalTemplatesRef = listGoalTemplatesRef;
-
-exports.listGoalTemplates = function listGoalTemplates(dc) {
-  return executeQuery(listGoalTemplatesRef(dc));
 };

--- a/mobile/src/generated/dataconnect/index.d.ts
+++ b/mobile/src/generated/dataconnect/index.d.ts
@@ -277,6 +277,35 @@ export interface GetClientVariables {
   id: UUIDString;
 }
 
+export interface GetReportData {
+  report?: {
+    id: UUIDString;
+    targetYear: number;
+    targetMonth: number;
+    summary?: string | null;
+    aiGenerated?: boolean | null;
+    pdfGenerated?: boolean | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & Report_Key;
+}
+
+export interface GetReportVariables {
+  id: UUIDString;
+}
+
 export interface GetSchedulesByRecurrenceIdData {
   schedules: ({
     id: UUIDString;
@@ -792,6 +821,258 @@ export interface VisitRecord_Key {
   __typename?: 'VisitRecord_Key';
 }
 
+interface ListCareLevelsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListCareLevelsData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListCareLevelsData, undefined>;
+  operationName: string;
+}
+export const listCareLevelsRef: ListCareLevelsRef;
+
+export function listCareLevels(): QueryPromise<ListCareLevelsData, undefined>;
+export function listCareLevels(dc: DataConnect): QueryPromise<ListCareLevelsData, undefined>;
+
+interface ListVisitReasonsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListVisitReasonsData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListVisitReasonsData, undefined>;
+  operationName: string;
+}
+export const listVisitReasonsRef: ListVisitReasonsRef;
+
+export function listVisitReasons(): QueryPromise<ListVisitReasonsData, undefined>;
+export function listVisitReasons(dc: DataConnect): QueryPromise<ListVisitReasonsData, undefined>;
+
+interface ListServiceTypesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
+  operationName: string;
+}
+export const listServiceTypesRef: ListServiceTypesRef;
+
+export function listServiceTypes(vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
+export function listServiceTypes(dc: DataConnect, vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
+
+interface ListServiceItemsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
+  operationName: string;
+}
+export const listServiceItemsRef: ListServiceItemsRef;
+
+export function listServiceItems(vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
+export function listServiceItems(dc: DataConnect, vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
+
+interface GetStaffByFirebaseUidRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+  operationName: string;
+}
+export const getStaffByFirebaseUidRef: GetStaffByFirebaseUidRef;
+
+export function getStaffByFirebaseUid(vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+export function getStaffByFirebaseUid(dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+
+interface ListStaffRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
+  operationName: string;
+}
+export const listStaffRef: ListStaffRef;
+
+export function listStaff(vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
+export function listStaff(dc: DataConnect, vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
+
+interface ListClientsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
+  operationName: string;
+}
+export const listClientsRef: ListClientsRef;
+
+export function listClients(vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
+export function listClients(dc: DataConnect, vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
+
+interface GetClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
+  operationName: string;
+}
+export const getClientRef: GetClientRef;
+
+export function getClient(vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
+export function getClient(dc: DataConnect, vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
+
+interface ListSchedulesByDateRangeRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+  operationName: string;
+}
+export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
+
+export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  operationName: string;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+
+export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface ListSchedulesByStaffRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+  operationName: string;
+}
+export const listSchedulesByStaffRef: ListSchedulesByStaffRef;
+
+export function listSchedulesByStaff(vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+export function listSchedulesByStaff(dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+
+interface ListVisitRecordsByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+  operationName: string;
+}
+export const listVisitRecordsByClientRef: ListVisitRecordsByClientRef;
+
+export function listVisitRecordsByClient(vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+export function listVisitRecordsByClient(dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+
+interface ListVisitRecordsByDateRangeRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+  operationName: string;
+}
+export const listVisitRecordsByDateRangeRef: ListVisitRecordsByDateRangeRef;
+
+export function listVisitRecordsByDateRange(vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+export function listVisitRecordsByDateRange(dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+
+interface GetVisitRecordRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
+  operationName: string;
+}
+export const getVisitRecordRef: GetVisitRecordRef;
+
+export function getVisitRecord(vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
+export function getVisitRecord(dc: DataConnect, vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
+
+interface ListReportsByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
+  operationName: string;
+}
+export const listReportsByClientRef: ListReportsByClientRef;
+
+export function listReportsByClient(vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
+export function listReportsByClient(dc: DataConnect, vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
+
+interface ListReportsByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+  operationName: string;
+}
+export const listReportsByFacilityRef: ListReportsByFacilityRef;
+
+export function listReportsByFacility(vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+export function listReportsByFacility(dc: DataConnect, vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+
+interface GetReportRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+  operationName: string;
+}
+export const getReportRef: GetReportRef;
+
+export function getReport(vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+export function getReport(dc: DataConnect, vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface ListCarePlansByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+  operationName: string;
+}
+export const listCarePlansByClientRef: ListCarePlansByClientRef;
+
+export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+
+interface ListCarePlansByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  operationName: string;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+
+export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface GetCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  operationName: string;
+}
+export const getCarePlanRef: GetCarePlanRef;
+
+export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface ListGoalTemplatesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+  operationName: string;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+
+export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
+
 interface CreateClientRef {
   /* Allow users to create refs without passing in DataConnect */
   (vars: CreateClientVariables): MutationRef<CreateClientData, CreateClientVariables>;
@@ -1055,244 +1336,4 @@ export const createServiceItemRef: CreateServiceItemRef;
 
 export function createServiceItem(vars: CreateServiceItemVariables): MutationPromise<CreateServiceItemData, CreateServiceItemVariables>;
 export function createServiceItem(dc: DataConnect, vars: CreateServiceItemVariables): MutationPromise<CreateServiceItemData, CreateServiceItemVariables>;
-
-interface ListCareLevelsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListCareLevelsData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListCareLevelsData, undefined>;
-  operationName: string;
-}
-export const listCareLevelsRef: ListCareLevelsRef;
-
-export function listCareLevels(): QueryPromise<ListCareLevelsData, undefined>;
-export function listCareLevels(dc: DataConnect): QueryPromise<ListCareLevelsData, undefined>;
-
-interface ListVisitReasonsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListVisitReasonsData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListVisitReasonsData, undefined>;
-  operationName: string;
-}
-export const listVisitReasonsRef: ListVisitReasonsRef;
-
-export function listVisitReasons(): QueryPromise<ListVisitReasonsData, undefined>;
-export function listVisitReasons(dc: DataConnect): QueryPromise<ListVisitReasonsData, undefined>;
-
-interface ListServiceTypesRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
-  operationName: string;
-}
-export const listServiceTypesRef: ListServiceTypesRef;
-
-export function listServiceTypes(vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
-export function listServiceTypes(dc: DataConnect, vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
-
-interface ListServiceItemsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
-  operationName: string;
-}
-export const listServiceItemsRef: ListServiceItemsRef;
-
-export function listServiceItems(vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
-export function listServiceItems(dc: DataConnect, vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
-
-interface GetStaffByFirebaseUidRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-  operationName: string;
-}
-export const getStaffByFirebaseUidRef: GetStaffByFirebaseUidRef;
-
-export function getStaffByFirebaseUid(vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-export function getStaffByFirebaseUid(dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-
-interface ListStaffRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
-  operationName: string;
-}
-export const listStaffRef: ListStaffRef;
-
-export function listStaff(vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
-export function listStaff(dc: DataConnect, vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
-
-interface ListClientsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
-  operationName: string;
-}
-export const listClientsRef: ListClientsRef;
-
-export function listClients(vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
-export function listClients(dc: DataConnect, vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
-
-interface GetClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
-  operationName: string;
-}
-export const getClientRef: GetClientRef;
-
-export function getClient(vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
-export function getClient(dc: DataConnect, vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
-
-interface ListSchedulesByDateRangeRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-  operationName: string;
-}
-export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
-
-export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-
-interface GetSchedulesByRecurrenceIdRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-  operationName: string;
-}
-export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
-
-export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-
-interface ListSchedulesByStaffRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-  operationName: string;
-}
-export const listSchedulesByStaffRef: ListSchedulesByStaffRef;
-
-export function listSchedulesByStaff(vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-export function listSchedulesByStaff(dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-
-interface ListVisitRecordsByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-  operationName: string;
-}
-export const listVisitRecordsByClientRef: ListVisitRecordsByClientRef;
-
-export function listVisitRecordsByClient(vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-export function listVisitRecordsByClient(dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-
-interface ListVisitRecordsByDateRangeRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-  operationName: string;
-}
-export const listVisitRecordsByDateRangeRef: ListVisitRecordsByDateRangeRef;
-
-export function listVisitRecordsByDateRange(vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-export function listVisitRecordsByDateRange(dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-
-interface GetVisitRecordRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
-  operationName: string;
-}
-export const getVisitRecordRef: GetVisitRecordRef;
-
-export function getVisitRecord(vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
-export function getVisitRecord(dc: DataConnect, vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
-
-interface ListReportsByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
-  operationName: string;
-}
-export const listReportsByClientRef: ListReportsByClientRef;
-
-export function listReportsByClient(vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
-export function listReportsByClient(dc: DataConnect, vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
-
-interface ListReportsByFacilityRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-  operationName: string;
-}
-export const listReportsByFacilityRef: ListReportsByFacilityRef;
-
-export function listReportsByFacility(vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-export function listReportsByFacility(dc: DataConnect, vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-
-interface ListCarePlansByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-  operationName: string;
-}
-export const listCarePlansByClientRef: ListCarePlansByClientRef;
-
-export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-
-interface ListCarePlansByFacilityRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-  operationName: string;
-}
-export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
-
-export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-
-interface GetCarePlanRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
-  operationName: string;
-}
-export const getCarePlanRef: GetCarePlanRef;
-
-export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
-export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
-
-interface ListGoalTemplatesRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListGoalTemplatesData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
-  operationName: string;
-}
-export const listGoalTemplatesRef: ListGoalTemplatesRef;
-
-export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
-export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
 

--- a/mobile/src/navigation/RootNavigator.tsx
+++ b/mobile/src/navigation/RootNavigator.tsx
@@ -18,6 +18,8 @@ import ClientDetailScreen from '../screens/clients/ClientDetailScreen';
 import SettingsScreen from '../screens/settings/SettingsScreen';
 import CarePlansScreen from '../screens/careplans/CarePlansScreen';
 import CarePlanDetailScreen from '../screens/careplans/CarePlanDetailScreen';
+import ReportsScreen from '../screens/reports/ReportsScreen';
+import ReportDetailScreen from '../screens/reports/ReportDetailScreen';
 
 export type RootStackParamList = {
   Login: undefined;
@@ -63,11 +65,17 @@ export type ClientStackParamList = {
 export type SettingsStackParamList = {
   SettingsMain: undefined;
   CarePlansStack: undefined;
+  ReportsStack: undefined;
 };
 
 export type CarePlansStackParamList = {
   CarePlansList: undefined;
   CarePlanDetail: { carePlanId: string };
+};
+
+export type ReportsStackParamList = {
+  ReportsList: undefined;
+  ReportDetail: { reportId: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -77,6 +85,7 @@ const ScheduleStack = createNativeStackNavigator<ScheduleStackParamList>();
 const ClientStack = createNativeStackNavigator<ClientStackParamList>();
 const SettingsStack = createNativeStackNavigator<SettingsStackParamList>();
 const CarePlansStack = createNativeStackNavigator<CarePlansStackParamList>();
+const ReportsStack = createNativeStackNavigator<ReportsStackParamList>();
 
 function RecordHistoryNavigator() {
   return (
@@ -114,11 +123,21 @@ function CarePlansNavigator() {
   );
 }
 
+function ReportsNavigator() {
+  return (
+    <ReportsStack.Navigator screenOptions={{ headerShown: false }}>
+      <ReportsStack.Screen name="ReportsList" component={ReportsScreen} />
+      <ReportsStack.Screen name="ReportDetail" component={ReportDetailScreen} />
+    </ReportsStack.Navigator>
+  );
+}
+
 function SettingsNavigator() {
   return (
     <SettingsStack.Navigator screenOptions={{ headerShown: false }}>
       <SettingsStack.Screen name="SettingsMain" component={SettingsScreen} />
       <SettingsStack.Screen name="CarePlansStack" component={CarePlansNavigator} />
+      <SettingsStack.Screen name="ReportsStack" component={ReportsNavigator} />
     </SettingsStack.Navigator>
   );
 }

--- a/mobile/src/screens/reports/ReportDetailScreen.tsx
+++ b/mobile/src/screens/reports/ReportDetailScreen.tsx
@@ -1,0 +1,331 @@
+import React, { useState, useEffect } from 'react';
+import { View, StyleSheet, ScrollView, Linking, Alert } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  IconButton,
+  Button,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRoute, useNavigation, RouteProp } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { dataConnect } from '../../lib/firebase';
+import { getReport, GetReportData } from '@sanwa-houkai-app/dataconnect';
+import { ReportsStackParamList } from '../../navigation/RootNavigator';
+
+type Report = NonNullable<GetReportData['report']>;
+
+type RouteProps = RouteProp<ReportsStackParamList, 'ReportDetail'>;
+type NavigationProp = NativeStackNavigationProp<ReportsStackParamList, 'ReportDetail'>;
+
+export default function ReportDetailScreen() {
+  const theme = useTheme();
+  const route = useRoute<RouteProps>();
+  const navigation = useNavigation<NavigationProp>();
+  const { reportId } = route.params;
+
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchReport = async () => {
+      try {
+        const result = await getReport(dataConnect, { id: reportId });
+        if (result.data.report) {
+          setReport(result.data.report);
+        } else {
+          setError('報告書が見つかりません');
+        }
+      } catch (err) {
+        console.error('Failed to load report:', err);
+        setError('報告書の読み込みに失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchReport();
+  }, [reportId]);
+
+  const formatYearMonth = (year: number, month: number) => {
+    return `${year}年${String(month).padStart(2, '0')}月`;
+  };
+
+  const formatDateTime = (dateStr: string) => {
+    return new Date(dateStr).toLocaleString('ja-JP');
+  };
+
+  const handleOpenPdf = async () => {
+    if (!report?.pdfUrl) {
+      Alert.alert('エラー', 'PDFが見つかりません');
+      return;
+    }
+
+    try {
+      const supported = await Linking.canOpenURL(report.pdfUrl);
+      if (supported) {
+        await Linking.openURL(report.pdfUrl);
+      } else {
+        Alert.alert('エラー', 'PDFを開けません');
+      }
+    } catch (err) {
+      console.error('Failed to open PDF:', err);
+      Alert.alert('エラー', 'PDFを開けませんでした');
+    }
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.header}>
+          <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+          <Text variant="titleLarge" style={styles.headerTitle}>
+            報告書詳細
+          </Text>
+          <View style={{ width: 48 }} />
+        </View>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error || '報告書が見つかりません'}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <IconButton icon="arrow-left" onPress={() => navigation.goBack()} />
+        <Text variant="titleLarge" style={styles.headerTitle}>
+          報告書詳細
+        </Text>
+        <View style={{ width: 48 }} />
+      </View>
+
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
+        {/* Basic Info */}
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <Text variant="headlineMedium" style={styles.yearMonth}>
+              {formatYearMonth(report.targetYear, report.targetMonth)}
+            </Text>
+            <Text variant="titleLarge" style={styles.clientName}>
+              {report.client.name}
+            </Text>
+            {report.client.careLevel && (
+              <View style={styles.infoRow}>
+                <Text variant="bodyMedium" style={styles.label}>
+                  要介護度
+                </Text>
+                <Chip compact>{report.client.careLevel.name}</Chip>
+              </View>
+            )}
+            <View style={styles.infoRow}>
+              <Text variant="bodyMedium" style={styles.label}>
+                担当者
+              </Text>
+              <Chip icon="account" compact>
+                {report.staff.name}
+              </Chip>
+            </View>
+            <View style={styles.badgeRow}>
+              {report.aiGenerated && (
+                <Chip
+                  icon="robot"
+                  compact
+                  style={{ backgroundColor: theme.colors.tertiaryContainer }}
+                >
+                  AI要約あり
+                </Chip>
+              )}
+              {report.pdfGenerated && (
+                <Chip
+                  icon="file-pdf-box"
+                  compact
+                  style={{ backgroundColor: theme.colors.primaryContainer }}
+                >
+                  PDF生成済
+                </Chip>
+              )}
+            </View>
+          </Card.Content>
+        </Card>
+
+        {/* PDF Download */}
+        {report.pdfUrl && (
+          <Button
+            mode="contained"
+            icon="file-pdf-box"
+            onPress={handleOpenPdf}
+            style={styles.pdfButton}
+          >
+            PDFを開く
+          </Button>
+        )}
+
+        {/* AI Summary */}
+        {report.summary && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <View style={styles.sectionHeader}>
+                <Text variant="titleMedium" style={styles.sectionTitle}>
+                  {report.aiGenerated ? 'AI月次要約' : '月次要約'}
+                </Text>
+                {report.aiGenerated && (
+                  <Chip
+                    icon="robot"
+                    compact
+                    textStyle={styles.chipText}
+                    style={{ backgroundColor: theme.colors.tertiaryContainer }}
+                  >
+                    AI
+                  </Chip>
+                )}
+              </View>
+              <Text variant="bodyMedium" style={styles.summaryText}>
+                {report.summary}
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* No Summary */}
+        {!report.summary && (
+          <Card style={styles.card} mode="elevated">
+            <Card.Content>
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                月次要約
+              </Text>
+              <Text variant="bodyMedium" style={styles.noDataText}>
+                要約はありません
+              </Text>
+            </Card.Content>
+          </Card>
+        )}
+
+        {/* Metadata */}
+        <View style={styles.metadata}>
+          <Text variant="bodySmall" style={styles.metadataText}>
+            作成: {formatDateTime(report.createdAt)}
+          </Text>
+          {report.updatedAt !== report.createdAt && (
+            <Text variant="bodySmall" style={styles.metadataText}>
+              更新: {formatDateTime(report.updatedAt)}
+            </Text>
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    backgroundColor: '#FFFFFF',
+  },
+  headerTitle: {
+    fontWeight: '600',
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    paddingBottom: 32,
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  card: {
+    marginBottom: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  yearMonth: {
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+  clientName: {
+    fontWeight: '600',
+    marginBottom: 16,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  label: {
+    width: 80,
+    color: '#757575',
+  },
+  badgeRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 4,
+  },
+  pdfButton: {
+    marginBottom: 16,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontWeight: '600',
+  },
+  summaryText: {
+    color: '#424242',
+    lineHeight: 24,
+  },
+  noDataText: {
+    color: '#9E9E9E',
+    fontStyle: 'italic',
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  metadata: {
+    marginTop: 8,
+    paddingHorizontal: 4,
+  },
+  metadataText: {
+    color: '#9E9E9E',
+    marginBottom: 4,
+  },
+});

--- a/mobile/src/screens/reports/ReportsScreen.tsx
+++ b/mobile/src/screens/reports/ReportsScreen.tsx
@@ -1,0 +1,366 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { View, StyleSheet, FlatList, RefreshControl, TouchableOpacity } from 'react-native';
+import {
+  Text,
+  useTheme,
+  Card,
+  Chip,
+  ActivityIndicator,
+  IconButton,
+  Menu,
+  Divider,
+} from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useStaff } from '../../hooks/useStaff';
+import { dataConnect } from '../../lib/firebase';
+import {
+  listReportsByFacility,
+  listClients,
+  ListReportsByFacilityData,
+  ListClientsData,
+} from '@sanwa-houkai-app/dataconnect';
+import { ReportsStackParamList } from '../../navigation/RootNavigator';
+
+type Report = ListReportsByFacilityData['reports'][0];
+type Client = ListClientsData['clients'][0];
+
+type NavigationProp = NativeStackNavigationProp<ReportsStackParamList, 'ReportsList'>;
+
+export default function ReportsScreen() {
+  const theme = useTheme();
+  const navigation = useNavigation<NavigationProp>();
+  const { facilityId, loading: staffLoading } = useStaff();
+
+  const [reports, setReports] = useState<Report[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Filter state
+  const [filterClientId, setFilterClientId] = useState<string | null>(null);
+  const [menuVisible, setMenuVisible] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    if (!facilityId) return;
+
+    try {
+      const [reportsRes, clientsRes] = await Promise.all([
+        listReportsByFacility(dataConnect, { facilityId }),
+        listClients(dataConnect, { facilityId }),
+      ]);
+
+      setReports(reportsRes.data.reports);
+      setClients(clientsRes.data.clients);
+      setError(null);
+    } catch (err) {
+      console.error('Failed to load reports:', err);
+      setError('データの読み込みに失敗しました');
+    }
+  }, [facilityId]);
+
+  useEffect(() => {
+    if (!facilityId) return;
+
+    const loadData = async () => {
+      setLoading(true);
+      await fetchData();
+      setLoading(false);
+    };
+
+    loadData();
+  }, [facilityId, fetchData]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await fetchData();
+    setRefreshing(false);
+  };
+
+  const handleReportPress = (report: Report) => {
+    navigation.navigate('ReportDetail', { reportId: report.id });
+  };
+
+  const formatYearMonth = (year: number, month: number) => {
+    return `${year}年${String(month).padStart(2, '0')}月`;
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return `${date.getFullYear()}/${String(date.getMonth() + 1).padStart(2, '0')}/${String(date.getDate()).padStart(2, '0')}`;
+  };
+
+  const filteredReports = filterClientId
+    ? reports.filter((r) => r.client.id === filterClientId)
+    : reports;
+
+  const selectedClientName = filterClientId
+    ? clients.find((c) => c.id === filterClientId)?.name || '不明'
+    : null;
+
+  const renderReport = ({ item }: { item: Report }) => {
+    return (
+      <TouchableOpacity onPress={() => handleReportPress(item)} activeOpacity={0.7}>
+        <Card style={styles.card} mode="elevated">
+          <Card.Content>
+            <View style={styles.cardHeader}>
+              <Text variant="titleLarge" style={styles.yearMonth}>
+                {formatYearMonth(item.targetYear, item.targetMonth)}
+              </Text>
+              <View style={styles.badges}>
+                {item.aiGenerated && (
+                  <Chip
+                    icon="robot"
+                    compact
+                    textStyle={styles.chipText}
+                    style={[styles.aiChip, { backgroundColor: theme.colors.tertiaryContainer }]}
+                  >
+                    AI
+                  </Chip>
+                )}
+                {item.pdfGenerated && item.pdfUrl && (
+                  <Chip icon="file-pdf-box" compact textStyle={styles.chipText}>
+                    PDF
+                  </Chip>
+                )}
+              </View>
+            </View>
+            <Text variant="titleMedium" style={styles.clientName}>
+              {item.client.name}
+            </Text>
+            {item.summary && (
+              <Text variant="bodyMedium" style={styles.summaryText} numberOfLines={2}>
+                {item.summary}
+              </Text>
+            )}
+            <View style={styles.cardFooter}>
+              <Text variant="bodySmall" style={styles.dateText}>
+                作成日: {formatDate(item.createdAt)}
+              </Text>
+              <Chip icon="account" compact textStyle={styles.chipText}>
+                {item.staff.name}
+              </Chip>
+            </View>
+          </Card.Content>
+        </Card>
+      </TouchableOpacity>
+    );
+  };
+
+  if (staffLoading || loading) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" />
+          <Text style={styles.loadingText}>読み込み中...</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!facilityId) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>スタッフ情報が見つかりません</Text>
+          <Text style={styles.subText}>管理者にお問い合わせください</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.container} edges={['top']}>
+        <View style={styles.loadingContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <IconButton
+            icon="arrow-left"
+            size={24}
+            onPress={() => navigation.goBack()}
+          />
+          <Text variant="headlineMedium" style={[styles.title, { color: theme.colors.primary }]}>
+            実施報告書
+          </Text>
+        </View>
+        <Menu
+          visible={menuVisible}
+          onDismiss={() => setMenuVisible(false)}
+          anchor={
+            <IconButton
+              icon="filter-variant"
+              size={24}
+              onPress={() => setMenuVisible(true)}
+              style={filterClientId ? { backgroundColor: theme.colors.primaryContainer } : undefined}
+            />
+          }
+        >
+          <Menu.Item
+            onPress={() => {
+              setFilterClientId(null);
+              setMenuVisible(false);
+            }}
+            title="すべて表示"
+            leadingIcon={filterClientId === null ? 'check' : undefined}
+          />
+          <Divider />
+          {clients.map((client) => (
+            <Menu.Item
+              key={client.id}
+              onPress={() => {
+                setFilterClientId(client.id);
+                setMenuVisible(false);
+              }}
+              title={client.name}
+              leadingIcon={filterClientId === client.id ? 'check' : undefined}
+            />
+          ))}
+        </Menu>
+      </View>
+
+      {filterClientId && (
+        <View style={styles.filterChipContainer}>
+          <Chip
+            icon="account"
+            onClose={() => setFilterClientId(null)}
+            style={styles.filterChip}
+          >
+            {selectedClientName}
+          </Chip>
+        </View>
+      )}
+
+      <FlatList
+        data={filteredReports}
+        renderItem={renderReport}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.listContent}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyContainer}>
+            <Text style={styles.emptyText}>
+              {filterClientId
+                ? 'この利用者の報告書はありません'
+                : '報告書がありません'}
+            </Text>
+            <Text style={styles.emptySubText}>
+              Web管理画面から報告書を作成できます
+            </Text>
+          </View>
+        }
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FAFAFA',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingRight: 8,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  title: {
+    fontWeight: '600',
+  },
+  filterChipContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 8,
+  },
+  filterChip: {
+    alignSelf: 'flex-start',
+  },
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  loadingText: {
+    marginTop: 12,
+    color: '#757575',
+  },
+  errorText: {
+    fontSize: 16,
+    color: '#B00020',
+  },
+  subText: {
+    marginTop: 8,
+    color: '#757575',
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 8,
+  },
+  card: {
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  yearMonth: {
+    fontWeight: '600',
+  },
+  badges: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  aiChip: {},
+  clientName: {
+    marginBottom: 8,
+  },
+  summaryText: {
+    color: '#757575',
+    marginBottom: 12,
+  },
+  cardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  dateText: {
+    color: '#9E9E9E',
+  },
+  chipText: {
+    fontSize: 12,
+  },
+  emptyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 48,
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#757575',
+  },
+  emptySubText: {
+    marginTop: 8,
+    fontSize: 14,
+    color: '#9E9E9E',
+  },
+});

--- a/mobile/src/screens/settings/SettingsScreen.tsx
+++ b/mobile/src/screens/settings/SettingsScreen.tsx
@@ -22,6 +22,10 @@ export default function SettingsScreen() {
     navigation.navigate('CarePlansStack');
   };
 
+  const handleReportsPress = () => {
+    navigation.navigate('ReportsStack');
+  };
+
   return (
     <SafeAreaView style={styles.container} edges={['top']}>
       <ScrollView>
@@ -48,14 +52,25 @@ export default function SettingsScreen() {
         <Divider style={styles.divider} />
 
         <List.Section>
-          <List.Subheader>メニュー</List.Subheader>
+          <List.Subheader>帳票</List.Subheader>
           <List.Item
-            title="帳票一覧"
-            description="報告書・計画書の出力"
-            left={(props) => <List.Icon {...props} icon="file-document-outline" />}
+            title="訪問介護計画書"
+            description="計画書の閲覧・PDF出力"
+            left={(props) => <List.Icon {...props} icon="clipboard-text-outline" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={handleCarePlansPress}
           />
+          <List.Item
+            title="実施報告書"
+            description="月次報告書の閲覧・PDF出力"
+            left={(props) => <List.Icon {...props} icon="file-chart-outline" />}
+            right={(props) => <List.Icon {...props} icon="chevron-right" />}
+            onPress={handleReportsPress}
+          />
+        </List.Section>
+
+        <List.Section>
+          <List.Subheader>管理</List.Subheader>
           <List.Item
             title="支援者管理"
             description="職員情報の管理"

--- a/web/src/generated/dataconnect/.guides/usage.md
+++ b/web/src/generated/dataconnect/.guides/usage.md
@@ -14,38 +14,38 @@ If a user is not using a supported framework, they can use the generated SDK dir
 Here's an example of how to use it with the first 5 operations:
 
 ```js
-import { createClient, updateClient, deleteClient, createSchedule, updateSchedule, deleteSchedule, cancelSchedule, completeSchedule, createVisitRecord, updateVisitRecord } from '@sanwa-houkai-app/dataconnect';
+import { listCareLevels, listVisitReasons, listServiceTypes, listServiceItems, getStaffByFirebaseUid, listStaff, listClients, getClient, listSchedulesByDateRange, getSchedulesByRecurrenceId } from '@sanwa-houkai-app/dataconnect';
 
 
-// Operation CreateClient:  For variables, look at type CreateClientVars in ../index.d.ts
-const { data } = await CreateClient(dataConnect, createClientVars);
+// Operation ListCareLevels: 
+const { data } = await ListCareLevels(dataConnect);
 
-// Operation UpdateClient:  For variables, look at type UpdateClientVars in ../index.d.ts
-const { data } = await UpdateClient(dataConnect, updateClientVars);
+// Operation ListVisitReasons: 
+const { data } = await ListVisitReasons(dataConnect);
 
-// Operation DeleteClient:  For variables, look at type DeleteClientVars in ../index.d.ts
-const { data } = await DeleteClient(dataConnect, deleteClientVars);
+// Operation ListServiceTypes:  For variables, look at type ListServiceTypesVars in ../index.d.ts
+const { data } = await ListServiceTypes(dataConnect, listServiceTypesVars);
 
-// Operation CreateSchedule:  For variables, look at type CreateScheduleVars in ../index.d.ts
-const { data } = await CreateSchedule(dataConnect, createScheduleVars);
+// Operation ListServiceItems:  For variables, look at type ListServiceItemsVars in ../index.d.ts
+const { data } = await ListServiceItems(dataConnect, listServiceItemsVars);
 
-// Operation UpdateSchedule:  For variables, look at type UpdateScheduleVars in ../index.d.ts
-const { data } = await UpdateSchedule(dataConnect, updateScheduleVars);
+// Operation GetStaffByFirebaseUid:  For variables, look at type GetStaffByFirebaseUidVars in ../index.d.ts
+const { data } = await GetStaffByFirebaseUid(dataConnect, getStaffByFirebaseUidVars);
 
-// Operation DeleteSchedule:  For variables, look at type DeleteScheduleVars in ../index.d.ts
-const { data } = await DeleteSchedule(dataConnect, deleteScheduleVars);
+// Operation ListStaff:  For variables, look at type ListStaffVars in ../index.d.ts
+const { data } = await ListStaff(dataConnect, listStaffVars);
 
-// Operation CancelSchedule:  For variables, look at type CancelScheduleVars in ../index.d.ts
-const { data } = await CancelSchedule(dataConnect, cancelScheduleVars);
+// Operation ListClients:  For variables, look at type ListClientsVars in ../index.d.ts
+const { data } = await ListClients(dataConnect, listClientsVars);
 
-// Operation CompleteSchedule:  For variables, look at type CompleteScheduleVars in ../index.d.ts
-const { data } = await CompleteSchedule(dataConnect, completeScheduleVars);
+// Operation GetClient:  For variables, look at type GetClientVars in ../index.d.ts
+const { data } = await GetClient(dataConnect, getClientVars);
 
-// Operation CreateVisitRecord:  For variables, look at type CreateVisitRecordVars in ../index.d.ts
-const { data } = await CreateVisitRecord(dataConnect, createVisitRecordVars);
+// Operation ListSchedulesByDateRange:  For variables, look at type ListSchedulesByDateRangeVars in ../index.d.ts
+const { data } = await ListSchedulesByDateRange(dataConnect, listSchedulesByDateRangeVars);
 
-// Operation UpdateVisitRecord:  For variables, look at type UpdateVisitRecordVars in ../index.d.ts
-const { data } = await UpdateVisitRecord(dataConnect, updateVisitRecordVars);
+// Operation GetSchedulesByRecurrenceId:  For variables, look at type GetSchedulesByRecurrenceIdVars in ../index.d.ts
+const { data } = await GetSchedulesByRecurrenceId(dataConnect, getSchedulesByRecurrenceIdVars);
 
 
 ```

--- a/web/src/generated/dataconnect/README.md
+++ b/web/src/generated/dataconnect/README.md
@@ -24,6 +24,7 @@ This README will guide you through the process of using the generated JavaScript
   - [*GetVisitRecord*](#getvisitrecord)
   - [*ListReportsByClient*](#listreportsbyclient)
   - [*ListReportsByFacility*](#listreportsbyfacility)
+  - [*GetReport*](#getreport)
   - [*ListCarePlansByClient*](#listcareplansbyclient)
   - [*ListCarePlansByFacility*](#listcareplansbyfacility)
   - [*GetCarePlan*](#getcareplan)
@@ -2045,6 +2046,136 @@ console.log(data.reports);
 executeQuery(ref).then((response) => {
   const data = response.data;
   console.log(data.reports);
+});
+```
+
+## GetReport
+You can execute the `GetReport` query using the following action shortcut function, or by calling `executeQuery()` after calling the following `QueryRef` function, both of which are defined in [dataconnect/index.d.ts](./index.d.ts):
+```typescript
+getReport(vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface GetReportRef {
+  ...
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+}
+export const getReportRef: GetReportRef;
+```
+You can also pass in a `DataConnect` instance to the action shortcut function or `QueryRef` function.
+```typescript
+getReport(dc: DataConnect, vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface GetReportRef {
+  ...
+  (dc: DataConnect, vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+}
+export const getReportRef: GetReportRef;
+```
+
+If you need the name of the operation without creating a ref, you can retrieve the operation name by calling the `operationName` property on the getReportRef:
+```typescript
+const name = getReportRef.operationName;
+console.log(name);
+```
+
+### Variables
+The `GetReport` query requires an argument of type `GetReportVariables`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+
+```typescript
+export interface GetReportVariables {
+  id: UUIDString;
+}
+```
+### Return Type
+Recall that executing the `GetReport` query returns a `QueryPromise` that resolves to an object with a `data` property.
+
+The `data` property is an object of type `GetReportData`, which is defined in [dataconnect/index.d.ts](./index.d.ts). It has the following fields:
+```typescript
+export interface GetReportData {
+  report?: {
+    id: UUIDString;
+    targetYear: number;
+    targetMonth: number;
+    summary?: string | null;
+    aiGenerated?: boolean | null;
+    pdfGenerated?: boolean | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & Report_Key;
+}
+```
+### Using `GetReport`'s action shortcut function
+
+```typescript
+import { getDataConnect } from 'firebase/data-connect';
+import { connectorConfig, getReport, GetReportVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetReport` query requires an argument of type `GetReportVariables`:
+const getReportVars: GetReportVariables = {
+  id: ..., 
+};
+
+// Call the `getReport()` function to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await getReport(getReportVars);
+// Variables can be defined inline as well.
+const { data } = await getReport({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the action shortcut function.
+const dataConnect = getDataConnect(connectorConfig);
+const { data } = await getReport(dataConnect, getReportVars);
+
+console.log(data.report);
+
+// Or, you can use the `Promise` API.
+getReport(getReportVars).then((response) => {
+  const data = response.data;
+  console.log(data.report);
+});
+```
+
+### Using `GetReport`'s `QueryRef` function
+
+```typescript
+import { getDataConnect, executeQuery } from 'firebase/data-connect';
+import { connectorConfig, getReportRef, GetReportVariables } from '@sanwa-houkai-app/dataconnect';
+
+// The `GetReport` query requires an argument of type `GetReportVariables`:
+const getReportVars: GetReportVariables = {
+  id: ..., 
+};
+
+// Call the `getReportRef()` function to get a reference to the query.
+const ref = getReportRef(getReportVars);
+// Variables can be defined inline as well.
+const ref = getReportRef({ id: ..., });
+
+// You can also pass in a `DataConnect` instance to the `QueryRef` function.
+const dataConnect = getDataConnect(connectorConfig);
+const ref = getReportRef(dataConnect, getReportVars);
+
+// Call `executeQuery()` on the reference to execute the query.
+// You can use the `await` keyword to wait for the promise to resolve.
+const { data } = await executeQuery(ref);
+
+console.log(data.report);
+
+// Or, you can use the `Promise` API.
+executeQuery(ref).then((response) => {
+  const data = response.data;
+  console.log(data.report);
 });
 ```
 

--- a/web/src/generated/dataconnect/esm/index.esm.js
+++ b/web/src/generated/dataconnect/esm/index.esm.js
@@ -6,6 +6,237 @@ export const connectorConfig = {
   location: 'asia-northeast1'
 };
 
+export const listCareLevelsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCareLevels');
+}
+listCareLevelsRef.operationName = 'ListCareLevels';
+
+export function listCareLevels(dc) {
+  return executeQuery(listCareLevelsRef(dc));
+}
+
+export const listVisitReasonsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitReasons');
+}
+listVisitReasonsRef.operationName = 'ListVisitReasons';
+
+export function listVisitReasons(dc) {
+  return executeQuery(listVisitReasonsRef(dc));
+}
+
+export const listServiceTypesRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
+}
+listServiceTypesRef.operationName = 'ListServiceTypes';
+
+export function listServiceTypes(dcOrVars, vars) {
+  return executeQuery(listServiceTypesRef(dcOrVars, vars));
+}
+
+export const listServiceItemsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceItems', inputVars);
+}
+listServiceItemsRef.operationName = 'ListServiceItems';
+
+export function listServiceItems(dcOrVars, vars) {
+  return executeQuery(listServiceItemsRef(dcOrVars, vars));
+}
+
+export const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
+}
+getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
+
+export function getStaffByFirebaseUid(dcOrVars, vars) {
+  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
+}
+
+export const listStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListStaff', inputVars);
+}
+listStaffRef.operationName = 'ListStaff';
+
+export function listStaff(dcOrVars, vars) {
+  return executeQuery(listStaffRef(dcOrVars, vars));
+}
+
+export const listClientsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListClients', inputVars);
+}
+listClientsRef.operationName = 'ListClients';
+
+export function listClients(dcOrVars, vars) {
+  return executeQuery(listClientsRef(dcOrVars, vars));
+}
+
+export const getClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetClient', inputVars);
+}
+getClientRef.operationName = 'GetClient';
+
+export function getClient(dcOrVars, vars) {
+  return executeQuery(getClientRef(dcOrVars, vars));
+}
+
+export const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
+}
+listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
+
+export function listSchedulesByDateRange(dcOrVars, vars) {
+  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
+}
+
+export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+
+export function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+}
+
+export const listSchedulesByStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
+}
+listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
+
+export function listSchedulesByStaff(dcOrVars, vars) {
+  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
+}
+
+export const listVisitRecordsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
+}
+listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
+
+export function listVisitRecordsByClient(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
+}
+
+export const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
+}
+listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
+
+export function listVisitRecordsByDateRange(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
+}
+
+export const getVisitRecordRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
+}
+getVisitRecordRef.operationName = 'GetVisitRecord';
+
+export function getVisitRecord(dcOrVars, vars) {
+  return executeQuery(getVisitRecordRef(dcOrVars, vars));
+}
+
+export const listReportsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
+}
+listReportsByClientRef.operationName = 'ListReportsByClient';
+
+export function listReportsByClient(dcOrVars, vars) {
+  return executeQuery(listReportsByClientRef(dcOrVars, vars));
+}
+
+export const listReportsByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
+}
+listReportsByFacilityRef.operationName = 'ListReportsByFacility';
+
+export function listReportsByFacility(dcOrVars, vars) {
+  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
+}
+
+export const getReportRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetReport', inputVars);
+}
+getReportRef.operationName = 'GetReport';
+
+export function getReport(dcOrVars, vars) {
+  return executeQuery(getReportRef(dcOrVars, vars));
+}
+
+export const listCarePlansByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
+}
+listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
+
+export function listCarePlansByClient(dcOrVars, vars) {
+  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+}
+
+export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+
+export function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+}
+
+export const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+
+export function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+}
+
+export const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+
+export function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
+}
+
 export const createClientRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -246,225 +477,5 @@ createServiceItemRef.operationName = 'CreateServiceItem';
 
 export function createServiceItem(dcOrVars, vars) {
   return executeMutation(createServiceItemRef(dcOrVars, vars));
-}
-
-export const listCareLevelsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCareLevels');
-}
-listCareLevelsRef.operationName = 'ListCareLevels';
-
-export function listCareLevels(dc) {
-  return executeQuery(listCareLevelsRef(dc));
-}
-
-export const listVisitReasonsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitReasons');
-}
-listVisitReasonsRef.operationName = 'ListVisitReasons';
-
-export function listVisitReasons(dc) {
-  return executeQuery(listVisitReasonsRef(dc));
-}
-
-export const listServiceTypesRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
-}
-listServiceTypesRef.operationName = 'ListServiceTypes';
-
-export function listServiceTypes(dcOrVars, vars) {
-  return executeQuery(listServiceTypesRef(dcOrVars, vars));
-}
-
-export const listServiceItemsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceItems', inputVars);
-}
-listServiceItemsRef.operationName = 'ListServiceItems';
-
-export function listServiceItems(dcOrVars, vars) {
-  return executeQuery(listServiceItemsRef(dcOrVars, vars));
-}
-
-export const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
-}
-getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
-
-export function getStaffByFirebaseUid(dcOrVars, vars) {
-  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
-}
-
-export const listStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListStaff', inputVars);
-}
-listStaffRef.operationName = 'ListStaff';
-
-export function listStaff(dcOrVars, vars) {
-  return executeQuery(listStaffRef(dcOrVars, vars));
-}
-
-export const listClientsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListClients', inputVars);
-}
-listClientsRef.operationName = 'ListClients';
-
-export function listClients(dcOrVars, vars) {
-  return executeQuery(listClientsRef(dcOrVars, vars));
-}
-
-export const getClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetClient', inputVars);
-}
-getClientRef.operationName = 'GetClient';
-
-export function getClient(dcOrVars, vars) {
-  return executeQuery(getClientRef(dcOrVars, vars));
-}
-
-export const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
-}
-listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
-
-export function listSchedulesByDateRange(dcOrVars, vars) {
-  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
-}
-
-export const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
-}
-getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
-
-export function getSchedulesByRecurrenceId(dcOrVars, vars) {
-  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
-}
-
-export const listSchedulesByStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
-}
-listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
-
-export function listSchedulesByStaff(dcOrVars, vars) {
-  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
-}
-
-export const listVisitRecordsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
-}
-listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
-
-export function listVisitRecordsByClient(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
-}
-
-export const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
-}
-listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
-
-export function listVisitRecordsByDateRange(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
-}
-
-export const getVisitRecordRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
-}
-getVisitRecordRef.operationName = 'GetVisitRecord';
-
-export function getVisitRecord(dcOrVars, vars) {
-  return executeQuery(getVisitRecordRef(dcOrVars, vars));
-}
-
-export const listReportsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
-}
-listReportsByClientRef.operationName = 'ListReportsByClient';
-
-export function listReportsByClient(dcOrVars, vars) {
-  return executeQuery(listReportsByClientRef(dcOrVars, vars));
-}
-
-export const listReportsByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
-}
-listReportsByFacilityRef.operationName = 'ListReportsByFacility';
-
-export function listReportsByFacility(dcOrVars, vars) {
-  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
-}
-
-export const listCarePlansByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
-}
-listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
-
-export function listCarePlansByClient(dcOrVars, vars) {
-  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
-}
-
-export const listCarePlansByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
-}
-listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
-
-export function listCarePlansByFacility(dcOrVars, vars) {
-  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
-}
-
-export const getCarePlanRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetCarePlan', inputVars);
-}
-getCarePlanRef.operationName = 'GetCarePlan';
-
-export function getCarePlan(dcOrVars, vars) {
-  return executeQuery(getCarePlanRef(dcOrVars, vars));
-}
-
-export const listGoalTemplatesRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListGoalTemplates');
-}
-listGoalTemplatesRef.operationName = 'ListGoalTemplates';
-
-export function listGoalTemplates(dc) {
-  return executeQuery(listGoalTemplatesRef(dc));
 }
 

--- a/web/src/generated/dataconnect/index.cjs.js
+++ b/web/src/generated/dataconnect/index.cjs.js
@@ -7,6 +7,258 @@ const connectorConfig = {
 };
 exports.connectorConfig = connectorConfig;
 
+const listCareLevelsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCareLevels');
+}
+listCareLevelsRef.operationName = 'ListCareLevels';
+exports.listCareLevelsRef = listCareLevelsRef;
+
+exports.listCareLevels = function listCareLevels(dc) {
+  return executeQuery(listCareLevelsRef(dc));
+};
+
+const listVisitReasonsRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitReasons');
+}
+listVisitReasonsRef.operationName = 'ListVisitReasons';
+exports.listVisitReasonsRef = listVisitReasonsRef;
+
+exports.listVisitReasons = function listVisitReasons(dc) {
+  return executeQuery(listVisitReasonsRef(dc));
+};
+
+const listServiceTypesRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
+}
+listServiceTypesRef.operationName = 'ListServiceTypes';
+exports.listServiceTypesRef = listServiceTypesRef;
+
+exports.listServiceTypes = function listServiceTypes(dcOrVars, vars) {
+  return executeQuery(listServiceTypesRef(dcOrVars, vars));
+};
+
+const listServiceItemsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListServiceItems', inputVars);
+}
+listServiceItemsRef.operationName = 'ListServiceItems';
+exports.listServiceItemsRef = listServiceItemsRef;
+
+exports.listServiceItems = function listServiceItems(dcOrVars, vars) {
+  return executeQuery(listServiceItemsRef(dcOrVars, vars));
+};
+
+const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
+}
+getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
+exports.getStaffByFirebaseUidRef = getStaffByFirebaseUidRef;
+
+exports.getStaffByFirebaseUid = function getStaffByFirebaseUid(dcOrVars, vars) {
+  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
+};
+
+const listStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListStaff', inputVars);
+}
+listStaffRef.operationName = 'ListStaff';
+exports.listStaffRef = listStaffRef;
+
+exports.listStaff = function listStaff(dcOrVars, vars) {
+  return executeQuery(listStaffRef(dcOrVars, vars));
+};
+
+const listClientsRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListClients', inputVars);
+}
+listClientsRef.operationName = 'ListClients';
+exports.listClientsRef = listClientsRef;
+
+exports.listClients = function listClients(dcOrVars, vars) {
+  return executeQuery(listClientsRef(dcOrVars, vars));
+};
+
+const getClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetClient', inputVars);
+}
+getClientRef.operationName = 'GetClient';
+exports.getClientRef = getClientRef;
+
+exports.getClient = function getClient(dcOrVars, vars) {
+  return executeQuery(getClientRef(dcOrVars, vars));
+};
+
+const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
+}
+listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
+exports.listSchedulesByDateRangeRef = listSchedulesByDateRangeRef;
+
+exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, vars) {
+  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
+};
+
+const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
+}
+getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
+exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
+
+exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
+  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
+};
+
+const listSchedulesByStaffRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
+}
+listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
+exports.listSchedulesByStaffRef = listSchedulesByStaffRef;
+
+exports.listSchedulesByStaff = function listSchedulesByStaff(dcOrVars, vars) {
+  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
+};
+
+const listVisitRecordsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
+}
+listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
+exports.listVisitRecordsByClientRef = listVisitRecordsByClientRef;
+
+exports.listVisitRecordsByClient = function listVisitRecordsByClient(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
+};
+
+const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
+}
+listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
+exports.listVisitRecordsByDateRangeRef = listVisitRecordsByDateRangeRef;
+
+exports.listVisitRecordsByDateRange = function listVisitRecordsByDateRange(dcOrVars, vars) {
+  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
+};
+
+const getVisitRecordRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
+}
+getVisitRecordRef.operationName = 'GetVisitRecord';
+exports.getVisitRecordRef = getVisitRecordRef;
+
+exports.getVisitRecord = function getVisitRecord(dcOrVars, vars) {
+  return executeQuery(getVisitRecordRef(dcOrVars, vars));
+};
+
+const listReportsByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
+}
+listReportsByClientRef.operationName = 'ListReportsByClient';
+exports.listReportsByClientRef = listReportsByClientRef;
+
+exports.listReportsByClient = function listReportsByClient(dcOrVars, vars) {
+  return executeQuery(listReportsByClientRef(dcOrVars, vars));
+};
+
+const listReportsByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
+}
+listReportsByFacilityRef.operationName = 'ListReportsByFacility';
+exports.listReportsByFacilityRef = listReportsByFacilityRef;
+
+exports.listReportsByFacility = function listReportsByFacility(dcOrVars, vars) {
+  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
+};
+
+const getReportRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetReport', inputVars);
+}
+getReportRef.operationName = 'GetReport';
+exports.getReportRef = getReportRef;
+
+exports.getReport = function getReport(dcOrVars, vars) {
+  return executeQuery(getReportRef(dcOrVars, vars));
+};
+
+const listCarePlansByClientRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
+}
+listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
+exports.listCarePlansByClientRef = listCarePlansByClientRef;
+
+exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
+  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
+};
+
+const listCarePlansByFacilityRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
+}
+listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
+exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
+
+exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
+  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
+};
+
+const getCarePlanRef = (dcOrVars, vars) => {
+  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'GetCarePlan', inputVars);
+}
+getCarePlanRef.operationName = 'GetCarePlan';
+exports.getCarePlanRef = getCarePlanRef;
+
+exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
+  return executeQuery(getCarePlanRef(dcOrVars, vars));
+};
+
+const listGoalTemplatesRef = (dc) => {
+  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
+  dcInstance._useGeneratedSdk();
+  return queryRef(dcInstance, 'ListGoalTemplates');
+}
+listGoalTemplatesRef.operationName = 'ListGoalTemplates';
+exports.listGoalTemplatesRef = listGoalTemplatesRef;
+
+exports.listGoalTemplates = function listGoalTemplates(dc) {
+  return executeQuery(listGoalTemplatesRef(dc));
+};
+
 const createClientRef = (dcOrVars, vars) => {
   const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
   dcInstance._useGeneratedSdk();
@@ -269,244 +521,4 @@ exports.createServiceItemRef = createServiceItemRef;
 
 exports.createServiceItem = function createServiceItem(dcOrVars, vars) {
   return executeMutation(createServiceItemRef(dcOrVars, vars));
-};
-
-const listCareLevelsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCareLevels');
-}
-listCareLevelsRef.operationName = 'ListCareLevels';
-exports.listCareLevelsRef = listCareLevelsRef;
-
-exports.listCareLevels = function listCareLevels(dc) {
-  return executeQuery(listCareLevelsRef(dc));
-};
-
-const listVisitReasonsRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitReasons');
-}
-listVisitReasonsRef.operationName = 'ListVisitReasons';
-exports.listVisitReasonsRef = listVisitReasonsRef;
-
-exports.listVisitReasons = function listVisitReasons(dc) {
-  return executeQuery(listVisitReasonsRef(dc));
-};
-
-const listServiceTypesRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceTypes', inputVars);
-}
-listServiceTypesRef.operationName = 'ListServiceTypes';
-exports.listServiceTypesRef = listServiceTypesRef;
-
-exports.listServiceTypes = function listServiceTypes(dcOrVars, vars) {
-  return executeQuery(listServiceTypesRef(dcOrVars, vars));
-};
-
-const listServiceItemsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListServiceItems', inputVars);
-}
-listServiceItemsRef.operationName = 'ListServiceItems';
-exports.listServiceItemsRef = listServiceItemsRef;
-
-exports.listServiceItems = function listServiceItems(dcOrVars, vars) {
-  return executeQuery(listServiceItemsRef(dcOrVars, vars));
-};
-
-const getStaffByFirebaseUidRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetStaffByFirebaseUid', inputVars);
-}
-getStaffByFirebaseUidRef.operationName = 'GetStaffByFirebaseUid';
-exports.getStaffByFirebaseUidRef = getStaffByFirebaseUidRef;
-
-exports.getStaffByFirebaseUid = function getStaffByFirebaseUid(dcOrVars, vars) {
-  return executeQuery(getStaffByFirebaseUidRef(dcOrVars, vars));
-};
-
-const listStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListStaff', inputVars);
-}
-listStaffRef.operationName = 'ListStaff';
-exports.listStaffRef = listStaffRef;
-
-exports.listStaff = function listStaff(dcOrVars, vars) {
-  return executeQuery(listStaffRef(dcOrVars, vars));
-};
-
-const listClientsRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListClients', inputVars);
-}
-listClientsRef.operationName = 'ListClients';
-exports.listClientsRef = listClientsRef;
-
-exports.listClients = function listClients(dcOrVars, vars) {
-  return executeQuery(listClientsRef(dcOrVars, vars));
-};
-
-const getClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetClient', inputVars);
-}
-getClientRef.operationName = 'GetClient';
-exports.getClientRef = getClientRef;
-
-exports.getClient = function getClient(dcOrVars, vars) {
-  return executeQuery(getClientRef(dcOrVars, vars));
-};
-
-const listSchedulesByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByDateRange', inputVars);
-}
-listSchedulesByDateRangeRef.operationName = 'ListSchedulesByDateRange';
-exports.listSchedulesByDateRangeRef = listSchedulesByDateRangeRef;
-
-exports.listSchedulesByDateRange = function listSchedulesByDateRange(dcOrVars, vars) {
-  return executeQuery(listSchedulesByDateRangeRef(dcOrVars, vars));
-};
-
-const getSchedulesByRecurrenceIdRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetSchedulesByRecurrenceId', inputVars);
-}
-getSchedulesByRecurrenceIdRef.operationName = 'GetSchedulesByRecurrenceId';
-exports.getSchedulesByRecurrenceIdRef = getSchedulesByRecurrenceIdRef;
-
-exports.getSchedulesByRecurrenceId = function getSchedulesByRecurrenceId(dcOrVars, vars) {
-  return executeQuery(getSchedulesByRecurrenceIdRef(dcOrVars, vars));
-};
-
-const listSchedulesByStaffRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListSchedulesByStaff', inputVars);
-}
-listSchedulesByStaffRef.operationName = 'ListSchedulesByStaff';
-exports.listSchedulesByStaffRef = listSchedulesByStaffRef;
-
-exports.listSchedulesByStaff = function listSchedulesByStaff(dcOrVars, vars) {
-  return executeQuery(listSchedulesByStaffRef(dcOrVars, vars));
-};
-
-const listVisitRecordsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByClient', inputVars);
-}
-listVisitRecordsByClientRef.operationName = 'ListVisitRecordsByClient';
-exports.listVisitRecordsByClientRef = listVisitRecordsByClientRef;
-
-exports.listVisitRecordsByClient = function listVisitRecordsByClient(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByClientRef(dcOrVars, vars));
-};
-
-const listVisitRecordsByDateRangeRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListVisitRecordsByDateRange', inputVars);
-}
-listVisitRecordsByDateRangeRef.operationName = 'ListVisitRecordsByDateRange';
-exports.listVisitRecordsByDateRangeRef = listVisitRecordsByDateRangeRef;
-
-exports.listVisitRecordsByDateRange = function listVisitRecordsByDateRange(dcOrVars, vars) {
-  return executeQuery(listVisitRecordsByDateRangeRef(dcOrVars, vars));
-};
-
-const getVisitRecordRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetVisitRecord', inputVars);
-}
-getVisitRecordRef.operationName = 'GetVisitRecord';
-exports.getVisitRecordRef = getVisitRecordRef;
-
-exports.getVisitRecord = function getVisitRecord(dcOrVars, vars) {
-  return executeQuery(getVisitRecordRef(dcOrVars, vars));
-};
-
-const listReportsByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByClient', inputVars);
-}
-listReportsByClientRef.operationName = 'ListReportsByClient';
-exports.listReportsByClientRef = listReportsByClientRef;
-
-exports.listReportsByClient = function listReportsByClient(dcOrVars, vars) {
-  return executeQuery(listReportsByClientRef(dcOrVars, vars));
-};
-
-const listReportsByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListReportsByFacility', inputVars);
-}
-listReportsByFacilityRef.operationName = 'ListReportsByFacility';
-exports.listReportsByFacilityRef = listReportsByFacilityRef;
-
-exports.listReportsByFacility = function listReportsByFacility(dcOrVars, vars) {
-  return executeQuery(listReportsByFacilityRef(dcOrVars, vars));
-};
-
-const listCarePlansByClientRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByClient', inputVars);
-}
-listCarePlansByClientRef.operationName = 'ListCarePlansByClient';
-exports.listCarePlansByClientRef = listCarePlansByClientRef;
-
-exports.listCarePlansByClient = function listCarePlansByClient(dcOrVars, vars) {
-  return executeQuery(listCarePlansByClientRef(dcOrVars, vars));
-};
-
-const listCarePlansByFacilityRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListCarePlansByFacility', inputVars);
-}
-listCarePlansByFacilityRef.operationName = 'ListCarePlansByFacility';
-exports.listCarePlansByFacilityRef = listCarePlansByFacilityRef;
-
-exports.listCarePlansByFacility = function listCarePlansByFacility(dcOrVars, vars) {
-  return executeQuery(listCarePlansByFacilityRef(dcOrVars, vars));
-};
-
-const getCarePlanRef = (dcOrVars, vars) => {
-  const { dc: dcInstance, vars: inputVars} = validateArgs(connectorConfig, dcOrVars, vars, true);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'GetCarePlan', inputVars);
-}
-getCarePlanRef.operationName = 'GetCarePlan';
-exports.getCarePlanRef = getCarePlanRef;
-
-exports.getCarePlan = function getCarePlan(dcOrVars, vars) {
-  return executeQuery(getCarePlanRef(dcOrVars, vars));
-};
-
-const listGoalTemplatesRef = (dc) => {
-  const { dc: dcInstance} = validateArgs(connectorConfig, dc, undefined);
-  dcInstance._useGeneratedSdk();
-  return queryRef(dcInstance, 'ListGoalTemplates');
-}
-listGoalTemplatesRef.operationName = 'ListGoalTemplates';
-exports.listGoalTemplatesRef = listGoalTemplatesRef;
-
-exports.listGoalTemplates = function listGoalTemplates(dc) {
-  return executeQuery(listGoalTemplatesRef(dc));
 };

--- a/web/src/generated/dataconnect/index.d.ts
+++ b/web/src/generated/dataconnect/index.d.ts
@@ -277,6 +277,35 @@ export interface GetClientVariables {
   id: UUIDString;
 }
 
+export interface GetReportData {
+  report?: {
+    id: UUIDString;
+    targetYear: number;
+    targetMonth: number;
+    summary?: string | null;
+    aiGenerated?: boolean | null;
+    pdfGenerated?: boolean | null;
+    pdfUrl?: string | null;
+    createdAt: TimestampString;
+    updatedAt: TimestampString;
+    client: {
+      id: UUIDString;
+      name: string;
+      careLevel?: {
+        name: string;
+      };
+    } & Client_Key;
+      staff: {
+        id: UUIDString;
+        name: string;
+      } & Staff_Key;
+  } & Report_Key;
+}
+
+export interface GetReportVariables {
+  id: UUIDString;
+}
+
 export interface GetSchedulesByRecurrenceIdData {
   schedules: ({
     id: UUIDString;
@@ -792,6 +821,258 @@ export interface VisitRecord_Key {
   __typename?: 'VisitRecord_Key';
 }
 
+interface ListCareLevelsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListCareLevelsData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListCareLevelsData, undefined>;
+  operationName: string;
+}
+export const listCareLevelsRef: ListCareLevelsRef;
+
+export function listCareLevels(): QueryPromise<ListCareLevelsData, undefined>;
+export function listCareLevels(dc: DataConnect): QueryPromise<ListCareLevelsData, undefined>;
+
+interface ListVisitReasonsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListVisitReasonsData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListVisitReasonsData, undefined>;
+  operationName: string;
+}
+export const listVisitReasonsRef: ListVisitReasonsRef;
+
+export function listVisitReasons(): QueryPromise<ListVisitReasonsData, undefined>;
+export function listVisitReasons(dc: DataConnect): QueryPromise<ListVisitReasonsData, undefined>;
+
+interface ListServiceTypesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
+  operationName: string;
+}
+export const listServiceTypesRef: ListServiceTypesRef;
+
+export function listServiceTypes(vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
+export function listServiceTypes(dc: DataConnect, vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
+
+interface ListServiceItemsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
+  operationName: string;
+}
+export const listServiceItemsRef: ListServiceItemsRef;
+
+export function listServiceItems(vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
+export function listServiceItems(dc: DataConnect, vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
+
+interface GetStaffByFirebaseUidRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+  operationName: string;
+}
+export const getStaffByFirebaseUidRef: GetStaffByFirebaseUidRef;
+
+export function getStaffByFirebaseUid(vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+export function getStaffByFirebaseUid(dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
+
+interface ListStaffRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
+  operationName: string;
+}
+export const listStaffRef: ListStaffRef;
+
+export function listStaff(vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
+export function listStaff(dc: DataConnect, vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
+
+interface ListClientsRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
+  operationName: string;
+}
+export const listClientsRef: ListClientsRef;
+
+export function listClients(vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
+export function listClients(dc: DataConnect, vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
+
+interface GetClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
+  operationName: string;
+}
+export const getClientRef: GetClientRef;
+
+export function getClient(vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
+export function getClient(dc: DataConnect, vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
+
+interface ListSchedulesByDateRangeRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+  operationName: string;
+}
+export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
+
+export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
+
+interface GetSchedulesByRecurrenceIdRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+  operationName: string;
+}
+export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
+
+export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
+
+interface ListSchedulesByStaffRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+  operationName: string;
+}
+export const listSchedulesByStaffRef: ListSchedulesByStaffRef;
+
+export function listSchedulesByStaff(vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+export function listSchedulesByStaff(dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
+
+interface ListVisitRecordsByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+  operationName: string;
+}
+export const listVisitRecordsByClientRef: ListVisitRecordsByClientRef;
+
+export function listVisitRecordsByClient(vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+export function listVisitRecordsByClient(dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
+
+interface ListVisitRecordsByDateRangeRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+  operationName: string;
+}
+export const listVisitRecordsByDateRangeRef: ListVisitRecordsByDateRangeRef;
+
+export function listVisitRecordsByDateRange(vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+export function listVisitRecordsByDateRange(dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
+
+interface GetVisitRecordRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
+  operationName: string;
+}
+export const getVisitRecordRef: GetVisitRecordRef;
+
+export function getVisitRecord(vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
+export function getVisitRecord(dc: DataConnect, vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
+
+interface ListReportsByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
+  operationName: string;
+}
+export const listReportsByClientRef: ListReportsByClientRef;
+
+export function listReportsByClient(vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
+export function listReportsByClient(dc: DataConnect, vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
+
+interface ListReportsByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+  operationName: string;
+}
+export const listReportsByFacilityRef: ListReportsByFacilityRef;
+
+export function listReportsByFacility(vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+export function listReportsByFacility(dc: DataConnect, vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
+
+interface GetReportRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetReportVariables): QueryRef<GetReportData, GetReportVariables>;
+  operationName: string;
+}
+export const getReportRef: GetReportRef;
+
+export function getReport(vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+export function getReport(dc: DataConnect, vars: GetReportVariables): QueryPromise<GetReportData, GetReportVariables>;
+
+interface ListCarePlansByClientRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+  operationName: string;
+}
+export const listCarePlansByClientRef: ListCarePlansByClientRef;
+
+export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
+
+interface ListCarePlansByFacilityRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+  operationName: string;
+}
+export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
+
+export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
+
+interface GetCarePlanRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
+  operationName: string;
+}
+export const getCarePlanRef: GetCarePlanRef;
+
+export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
+
+interface ListGoalTemplatesRef {
+  /* Allow users to create refs without passing in DataConnect */
+  (): QueryRef<ListGoalTemplatesData, undefined>;
+  /* Allow users to pass in custom DataConnect instances */
+  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
+  operationName: string;
+}
+export const listGoalTemplatesRef: ListGoalTemplatesRef;
+
+export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
+export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
+
 interface CreateClientRef {
   /* Allow users to create refs without passing in DataConnect */
   (vars: CreateClientVariables): MutationRef<CreateClientData, CreateClientVariables>;
@@ -1055,244 +1336,4 @@ export const createServiceItemRef: CreateServiceItemRef;
 
 export function createServiceItem(vars: CreateServiceItemVariables): MutationPromise<CreateServiceItemData, CreateServiceItemVariables>;
 export function createServiceItem(dc: DataConnect, vars: CreateServiceItemVariables): MutationPromise<CreateServiceItemData, CreateServiceItemVariables>;
-
-interface ListCareLevelsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListCareLevelsData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListCareLevelsData, undefined>;
-  operationName: string;
-}
-export const listCareLevelsRef: ListCareLevelsRef;
-
-export function listCareLevels(): QueryPromise<ListCareLevelsData, undefined>;
-export function listCareLevels(dc: DataConnect): QueryPromise<ListCareLevelsData, undefined>;
-
-interface ListVisitReasonsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListVisitReasonsData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListVisitReasonsData, undefined>;
-  operationName: string;
-}
-export const listVisitReasonsRef: ListVisitReasonsRef;
-
-export function listVisitReasons(): QueryPromise<ListVisitReasonsData, undefined>;
-export function listVisitReasons(dc: DataConnect): QueryPromise<ListVisitReasonsData, undefined>;
-
-interface ListServiceTypesRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListServiceTypesVariables): QueryRef<ListServiceTypesData, ListServiceTypesVariables>;
-  operationName: string;
-}
-export const listServiceTypesRef: ListServiceTypesRef;
-
-export function listServiceTypes(vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
-export function listServiceTypes(dc: DataConnect, vars: ListServiceTypesVariables): QueryPromise<ListServiceTypesData, ListServiceTypesVariables>;
-
-interface ListServiceItemsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListServiceItemsVariables): QueryRef<ListServiceItemsData, ListServiceItemsVariables>;
-  operationName: string;
-}
-export const listServiceItemsRef: ListServiceItemsRef;
-
-export function listServiceItems(vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
-export function listServiceItems(dc: DataConnect, vars: ListServiceItemsVariables): QueryPromise<ListServiceItemsData, ListServiceItemsVariables>;
-
-interface GetStaffByFirebaseUidRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryRef<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-  operationName: string;
-}
-export const getStaffByFirebaseUidRef: GetStaffByFirebaseUidRef;
-
-export function getStaffByFirebaseUid(vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-export function getStaffByFirebaseUid(dc: DataConnect, vars: GetStaffByFirebaseUidVariables): QueryPromise<GetStaffByFirebaseUidData, GetStaffByFirebaseUidVariables>;
-
-interface ListStaffRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListStaffVariables): QueryRef<ListStaffData, ListStaffVariables>;
-  operationName: string;
-}
-export const listStaffRef: ListStaffRef;
-
-export function listStaff(vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
-export function listStaff(dc: DataConnect, vars: ListStaffVariables): QueryPromise<ListStaffData, ListStaffVariables>;
-
-interface ListClientsRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListClientsVariables): QueryRef<ListClientsData, ListClientsVariables>;
-  operationName: string;
-}
-export const listClientsRef: ListClientsRef;
-
-export function listClients(vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
-export function listClients(dc: DataConnect, vars: ListClientsVariables): QueryPromise<ListClientsData, ListClientsVariables>;
-
-interface GetClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetClientVariables): QueryRef<GetClientData, GetClientVariables>;
-  operationName: string;
-}
-export const getClientRef: GetClientRef;
-
-export function getClient(vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
-export function getClient(dc: DataConnect, vars: GetClientVariables): QueryPromise<GetClientData, GetClientVariables>;
-
-interface ListSchedulesByDateRangeRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryRef<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-  operationName: string;
-}
-export const listSchedulesByDateRangeRef: ListSchedulesByDateRangeRef;
-
-export function listSchedulesByDateRange(vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-export function listSchedulesByDateRange(dc: DataConnect, vars: ListSchedulesByDateRangeVariables): QueryPromise<ListSchedulesByDateRangeData, ListSchedulesByDateRangeVariables>;
-
-interface GetSchedulesByRecurrenceIdRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryRef<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-  operationName: string;
-}
-export const getSchedulesByRecurrenceIdRef: GetSchedulesByRecurrenceIdRef;
-
-export function getSchedulesByRecurrenceId(vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-export function getSchedulesByRecurrenceId(dc: DataConnect, vars: GetSchedulesByRecurrenceIdVariables): QueryPromise<GetSchedulesByRecurrenceIdData, GetSchedulesByRecurrenceIdVariables>;
-
-interface ListSchedulesByStaffRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryRef<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-  operationName: string;
-}
-export const listSchedulesByStaffRef: ListSchedulesByStaffRef;
-
-export function listSchedulesByStaff(vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-export function listSchedulesByStaff(dc: DataConnect, vars: ListSchedulesByStaffVariables): QueryPromise<ListSchedulesByStaffData, ListSchedulesByStaffVariables>;
-
-interface ListVisitRecordsByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryRef<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-  operationName: string;
-}
-export const listVisitRecordsByClientRef: ListVisitRecordsByClientRef;
-
-export function listVisitRecordsByClient(vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-export function listVisitRecordsByClient(dc: DataConnect, vars: ListVisitRecordsByClientVariables): QueryPromise<ListVisitRecordsByClientData, ListVisitRecordsByClientVariables>;
-
-interface ListVisitRecordsByDateRangeRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryRef<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-  operationName: string;
-}
-export const listVisitRecordsByDateRangeRef: ListVisitRecordsByDateRangeRef;
-
-export function listVisitRecordsByDateRange(vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-export function listVisitRecordsByDateRange(dc: DataConnect, vars: ListVisitRecordsByDateRangeVariables): QueryPromise<ListVisitRecordsByDateRangeData, ListVisitRecordsByDateRangeVariables>;
-
-interface GetVisitRecordRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetVisitRecordVariables): QueryRef<GetVisitRecordData, GetVisitRecordVariables>;
-  operationName: string;
-}
-export const getVisitRecordRef: GetVisitRecordRef;
-
-export function getVisitRecord(vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
-export function getVisitRecord(dc: DataConnect, vars: GetVisitRecordVariables): QueryPromise<GetVisitRecordData, GetVisitRecordVariables>;
-
-interface ListReportsByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListReportsByClientVariables): QueryRef<ListReportsByClientData, ListReportsByClientVariables>;
-  operationName: string;
-}
-export const listReportsByClientRef: ListReportsByClientRef;
-
-export function listReportsByClient(vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
-export function listReportsByClient(dc: DataConnect, vars: ListReportsByClientVariables): QueryPromise<ListReportsByClientData, ListReportsByClientVariables>;
-
-interface ListReportsByFacilityRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListReportsByFacilityVariables): QueryRef<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-  operationName: string;
-}
-export const listReportsByFacilityRef: ListReportsByFacilityRef;
-
-export function listReportsByFacility(vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-export function listReportsByFacility(dc: DataConnect, vars: ListReportsByFacilityVariables): QueryPromise<ListReportsByFacilityData, ListReportsByFacilityVariables>;
-
-interface ListCarePlansByClientRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListCarePlansByClientVariables): QueryRef<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-  operationName: string;
-}
-export const listCarePlansByClientRef: ListCarePlansByClientRef;
-
-export function listCarePlansByClient(vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-export function listCarePlansByClient(dc: DataConnect, vars: ListCarePlansByClientVariables): QueryPromise<ListCarePlansByClientData, ListCarePlansByClientVariables>;
-
-interface ListCarePlansByFacilityRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryRef<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-  operationName: string;
-}
-export const listCarePlansByFacilityRef: ListCarePlansByFacilityRef;
-
-export function listCarePlansByFacility(vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-export function listCarePlansByFacility(dc: DataConnect, vars: ListCarePlansByFacilityVariables): QueryPromise<ListCarePlansByFacilityData, ListCarePlansByFacilityVariables>;
-
-interface GetCarePlanRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect, vars: GetCarePlanVariables): QueryRef<GetCarePlanData, GetCarePlanVariables>;
-  operationName: string;
-}
-export const getCarePlanRef: GetCarePlanRef;
-
-export function getCarePlan(vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
-export function getCarePlan(dc: DataConnect, vars: GetCarePlanVariables): QueryPromise<GetCarePlanData, GetCarePlanVariables>;
-
-interface ListGoalTemplatesRef {
-  /* Allow users to create refs without passing in DataConnect */
-  (): QueryRef<ListGoalTemplatesData, undefined>;
-  /* Allow users to pass in custom DataConnect instances */
-  (dc: DataConnect): QueryRef<ListGoalTemplatesData, undefined>;
-  operationName: string;
-}
-export const listGoalTemplatesRef: ListGoalTemplatesRef;
-
-export function listGoalTemplates(): QueryPromise<ListGoalTemplatesData, undefined>;
-export function listGoalTemplates(dc: DataConnect): QueryPromise<ListGoalTemplatesData, undefined>;
 


### PR DESCRIPTION
## Summary
- モバイルアプリに実施報告書の表示機能を追加
- その他タブから「実施報告書」メニューでアクセス可能
- 一覧画面で利用者フィルター、詳細画面でPDF閲覧が可能

## Changes
- **GetReport クエリ追加**: DataConnect に単一報告書取得クエリを追加
- **ReportsScreen.tsx**: 報告書一覧画面（FlatList、フィルター、プルリフレッシュ）
- **ReportDetailScreen.tsx**: 報告書詳細画面（年月、AI要約、PDF閲覧ボタン）
- **RootNavigator.tsx**: ReportsStack ナビゲーション追加
- **SettingsScreen.tsx**: メニューを「帳票」「管理」セクションに分割

## Test plan
- [ ] その他タブ → 「実施報告書」メニューをタップ
- [ ] 報告書一覧が表示されることを確認
- [ ] 利用者フィルターが機能することを確認
- [ ] 報告書をタップして詳細画面に遷移することを確認
- [ ] PDFボタンでPDFが開くことを確認（署名付きURL）
- [ ] プルリフレッシュでデータが再取得されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)