### PR TITLE
Fix demo environment and add account switching docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **自動切り替え**: direnv（.envrc）でディレクトリ移動時に環境が自動設定される
 
+### アカウント確認・切り替え（重要）
+
+セッション開始時に環境を確認し、期待値と異なる場合は切り替える:
+
+```bash
+# 期待値
+# GitHub: sanwaminamihonda-eng
+# GCP: sanwaminamihonda@gmail.com / sanwa-houkai-app
+
+# GitHub アカウント切り替え
+gh auth switch -u sanwaminamihonda-eng
+
+# GCP アカウント切り替え
+gcloud config set account sanwaminamihonda@gmail.com
+gcloud config set project sanwa-houkai-app
+```
+
 ## 技術スタック
 
 | レイヤー | 技術 | 備考 |

--- a/web/src/contexts/DemoContext.tsx
+++ b/web/src/contexts/DemoContext.tsx
@@ -3,8 +3,9 @@
 import React, { createContext, useContext } from 'react';
 
 // デモ用固定値（環境変数で上書き可能）
-const DEMO_FACILITY_ID = process.env.NEXT_PUBLIC_DEMO_FACILITY_ID || 'demo-facility-001';
-const DEMO_STAFF_ID = process.env.NEXT_PUBLIC_DEMO_STAFF_ID || 'demo-staff-001';
+// シードデータ（demo-seed.sql）と一致させる
+const DEMO_FACILITY_ID = process.env.NEXT_PUBLIC_DEMO_FACILITY_ID || '00000000-0000-0000-0000-000000000001';
+const DEMO_STAFF_ID = process.env.NEXT_PUBLIC_DEMO_STAFF_ID || '00000000-0000-0000-0000-000000000011';
 
 interface DemoContextType {
   isDemo: true;


### PR DESCRIPTION
## Summary
- デモ環境のUUID不一致を修正（DemoContext.tsx）
- CLAUDE.mdにアカウント切り替え手順を追加
- シードデータをCloud SQLに投入済み

## 変更内容
- `DemoContext.tsx`: facilityId/staffIdをシードデータと一致させる
- `CLAUDE.md`: 環境設定セクションにアカウント切り替え手順を追加

## デモ環境データ
| 項目 | 件数 |
|------|------|
| 利用者 | 10名 |
| スケジュール | 91件 |
| 訪問記録 | 189件 |

## Test plan
- [ ] https://sanwa-houkai-app.web.app/demo にアクセス
- [ ] ダッシュボードに統計が表示される
- [ ] 利用者一覧に10名表示される
- [ ] スケジュールにデータが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)