### PR TITLE
Add back button to all pages in web app

### DIFF
--- a/web/src/app/careplans/page.tsx
+++ b/web/src/app/careplans/page.tsx
@@ -271,7 +271,7 @@ export default function CarePlansPage() {
 
   if (staffLoading || loading) {
     return (
-      <MainLayout title="訪問介護計画書">
+      <MainLayout title="訪問介護計画書" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
@@ -281,7 +281,7 @@ export default function CarePlansPage() {
 
   if (!facilityId) {
     return (
-      <MainLayout title="訪問介護計画書">
+      <MainLayout title="訪問介護計画書" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -291,14 +291,14 @@ export default function CarePlansPage() {
 
   if (error) {
     return (
-      <MainLayout title="訪問介護計画書">
+      <MainLayout title="訪問介護計画書" showBackButton backHref="/">
         <Alert severity="error">{error}</Alert>
       </MainLayout>
     );
   }
 
   return (
-    <MainLayout title="訪問介護計画書">
+    <MainLayout title="訪問介護計画書" showBackButton backHref="/">
       <Box>
         {/* Header */}
         <Card sx={{ mb: 3 }}>

--- a/web/src/app/clients/detail/page.tsx
+++ b/web/src/app/clients/detail/page.tsx
@@ -439,7 +439,7 @@ function ClientDetailContent() {
 
 export default function ClientDetailPage() {
   return (
-    <MainLayout title="利用者詳細">
+    <MainLayout title="利用者詳細" showBackButton backHref="/clients">
       <Suspense fallback={
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />

--- a/web/src/app/clients/page.tsx
+++ b/web/src/app/clients/page.tsx
@@ -120,7 +120,7 @@ export default function ClientsPage() {
 
   if (staffLoading || loading) {
     return (
-      <MainLayout title="利用者管理">
+      <MainLayout title="利用者管理" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
@@ -130,7 +130,7 @@ export default function ClientsPage() {
 
   if (!facilityId) {
     return (
-      <MainLayout title="利用者管理">
+      <MainLayout title="利用者管理" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -140,14 +140,14 @@ export default function ClientsPage() {
 
   if (error) {
     return (
-      <MainLayout title="利用者管理">
+      <MainLayout title="利用者管理" showBackButton backHref="/">
         <Alert severity="error">{error}</Alert>
       </MainLayout>
     );
   }
 
   return (
-    <MainLayout title="利用者管理">
+    <MainLayout title="利用者管理" showBackButton backHref="/">
       <Box>
         {/* Search & Actions */}
         <Card sx={{ mb: 3 }}>

--- a/web/src/app/records/detail/page.tsx
+++ b/web/src/app/records/detail/page.tsx
@@ -369,7 +369,7 @@ function RecordDetailContent() {
 
 export default function RecordDetailPage() {
   return (
-    <MainLayout title="記録詳細">
+    <MainLayout title="記録詳細" showBackButton backHref="/records">
       <Suspense fallback={
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />

--- a/web/src/app/records/new/page.tsx
+++ b/web/src/app/records/new/page.tsx
@@ -267,7 +267,7 @@ export default function NewRecordPage() {
 
   if (staffLoading || loadingMasters) {
     return (
-      <MainLayout title="新規記録入力">
+      <MainLayout title="新規記録入力" showBackButton backHref="/">
         <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', minHeight: 400 }}>
           <CircularProgress />
         </Box>
@@ -277,7 +277,7 @@ export default function NewRecordPage() {
 
   if (!staff || !facilityId) {
     return (
-      <MainLayout title="新規記録入力">
+      <MainLayout title="新規記録入力" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -287,7 +287,7 @@ export default function NewRecordPage() {
 
   return (
     <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
-      <MainLayout title="新規記録入力">
+      <MainLayout title="新規記録入力" showBackButton backHref="/">
         <Card>
           <CardContent>
             {/* Client Selection */}

--- a/web/src/app/records/page.tsx
+++ b/web/src/app/records/page.tsx
@@ -172,7 +172,7 @@ export default function RecordsPage() {
 
   if (staffLoading || loading) {
     return (
-      <MainLayout title="履歴一覧">
+      <MainLayout title="履歴一覧" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
@@ -182,7 +182,7 @@ export default function RecordsPage() {
 
   if (!facilityId) {
     return (
-      <MainLayout title="履歴一覧">
+      <MainLayout title="履歴一覧" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -192,14 +192,14 @@ export default function RecordsPage() {
 
   if (error) {
     return (
-      <MainLayout title="履歴一覧">
+      <MainLayout title="履歴一覧" showBackButton backHref="/">
         <Alert severity="error">{error}</Alert>
       </MainLayout>
     );
   }
 
   return (
-    <MainLayout title="履歴一覧">
+    <MainLayout title="履歴一覧" showBackButton backHref="/">
       <Box>
         {/* Filters */}
         <Card sx={{ mb: 3 }}>

--- a/web/src/app/reports/page.tsx
+++ b/web/src/app/reports/page.tsx
@@ -239,7 +239,7 @@ export default function ReportsPage() {
 
   if (staffLoading || loading) {
     return (
-      <MainLayout title="帳票・報告">
+      <MainLayout title="帳票・報告" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
@@ -249,7 +249,7 @@ export default function ReportsPage() {
 
   if (!facilityId) {
     return (
-      <MainLayout title="帳票・報告">
+      <MainLayout title="帳票・報告" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -259,14 +259,14 @@ export default function ReportsPage() {
 
   if (error) {
     return (
-      <MainLayout title="帳票・報告">
+      <MainLayout title="帳票・報告" showBackButton backHref="/">
         <Alert severity="error">{error}</Alert>
       </MainLayout>
     );
   }
 
   return (
-    <MainLayout title="帳票・報告">
+    <MainLayout title="帳票・報告" showBackButton backHref="/">
       <Box>
         {/* Header */}
         <Card sx={{ mb: 3 }}>

--- a/web/src/app/schedule/page.tsx
+++ b/web/src/app/schedule/page.tsx
@@ -751,7 +751,7 @@ export default function SchedulePage() {
 
   if (staffLoading || loading) {
     return (
-      <MainLayout title="スケジュール">
+      <MainLayout title="スケジュール" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
           <CircularProgress />
         </Box>
@@ -761,7 +761,7 @@ export default function SchedulePage() {
 
   if (!facilityId) {
     return (
-      <MainLayout title="スケジュール">
+      <MainLayout title="スケジュール" showBackButton backHref="/">
         <Alert severity="error">
           スタッフ情報が見つかりません。管理者にお問い合わせください。
         </Alert>
@@ -771,14 +771,14 @@ export default function SchedulePage() {
 
   if (error) {
     return (
-      <MainLayout title="スケジュール">
+      <MainLayout title="スケジュール" showBackButton backHref="/">
         <Alert severity="error">{error}</Alert>
       </MainLayout>
     );
   }
 
   return (
-    <MainLayout title="スケジュール">
+    <MainLayout title="スケジュール" showBackButton backHref="/">
       <Box>
         {/* Header */}
         <Card sx={{ mb: 2 }}>

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -5,7 +5,7 @@ import { MainLayout } from '@/components/layout';
 
 export default function SettingsPage() {
   return (
-    <MainLayout title="設定">
+    <MainLayout title="設定" showBackButton backHref="/">
       <Box>
         <Card>
           <CardContent sx={{ textAlign: 'center', py: 8 }}>

--- a/web/src/app/staff/page.tsx
+++ b/web/src/app/staff/page.tsx
@@ -5,7 +5,7 @@ import { MainLayout } from '@/components/layout';
 
 export default function StaffPage() {
   return (
-    <MainLayout title="支援者管理">
+    <MainLayout title="支援者管理" showBackButton backHref="/">
       <Box>
         <Card>
           <CardContent sx={{ textAlign: 'center', py: 8 }}>

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -12,14 +12,19 @@ import {
   MenuItem,
   Divider,
 } from '@mui/material';
+import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { useRouter } from 'next/navigation';
 import { DRAWER_WIDTH } from './Sidebar';
 import { useAuth } from '@/contexts/AuthContext';
 
 interface HeaderProps {
   title?: string;
+  showBackButton?: boolean;
+  backHref?: string;
 }
 
-export default function Header({ title = '訪問介護記録管理' }: HeaderProps) {
+export default function Header({ title = '訪問介護記録管理', showBackButton = false, backHref }: HeaderProps) {
+  const router = useRouter();
   const { user, signOut } = useAuth();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
@@ -48,6 +53,17 @@ export default function Header({ title = '訪問介護記録管理' }: HeaderPro
       }}
     >
       <Toolbar>
+        {showBackButton && (
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="戻る"
+            onClick={() => backHref ? router.push(backHref) : router.back()}
+            sx={{ mr: 2 }}
+          >
+            <ArrowBackIcon />
+          </IconButton>
+        )}
         <Typography variant="h6" noWrap component="div" sx={{ flexGrow: 1 }}>
           {title}
         </Typography>

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -9,14 +9,16 @@ import AuthGuard from '../AuthGuard';
 interface MainLayoutProps {
   children: React.ReactNode;
   title?: string;
+  showBackButton?: boolean;
+  backHref?: string;
 }
 
-export default function MainLayout({ children, title }: MainLayoutProps) {
+export default function MainLayout({ children, title, showBackButton, backHref }: MainLayoutProps) {
   return (
     <AuthGuard>
       <Box sx={{ display: 'flex', minHeight: '100vh' }}>
         <Sidebar />
-        <Header title={title} />
+        <Header title={title} showBackButton={showBackButton} backHref={backHref} />
         <Box
           component="main"
           sx={{


### PR DESCRIPTION
## Summary
- ダッシュボード以外の全ページにヘッダー左側の戻るボタンを追加
- Header/MainLayoutコンポーネントにshowBackButton/backHrefプロパティを追加
- 詳細ページは一覧ページへ、その他のページはダッシュボードへ遷移

## Test plan
- [ ] ダッシュボードから各ページに遷移して戻るボタンが表示されることを確認
- [ ] 戻るボタンクリックで正しいページに遷移することを確認
- [ ] ダッシュボードには戻るボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)