### PR TITLE
Add shared components for demo/production code reuse

### DIFF
--- a/web/src/app/clients/detail/page.tsx
+++ b/web/src/app/clients/detail/page.tsx
@@ -2,43 +2,18 @@
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import {
-  Box,
-  Typography,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Alert,
-  Button,
-  Grid,
-  Divider,
-  IconButton,
-  Tooltip,
-} from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  Phone as PhoneIcon,
-  LocationOn as LocationIcon,
-  Person as PersonIcon,
-  Cake as CakeIcon,
-  WarningAmber as WarningIcon,
-  Assignment as AssignmentIcon,
-  EventRepeat as EventRepeatIcon,
-  Notes as NotesIcon,
-} from '@mui/icons-material';
+import { Box, CircularProgress } from '@mui/material';
 import { MainLayout } from '@/components/layout';
+import { ClientDetailView, ClientForDetail } from '@/components/clients';
 import { dataConnect } from '@/lib/firebase';
-import { getClient, GetClientData } from '@sanwa-houkai-app/dataconnect';
-
-type Client = NonNullable<GetClientData['client']>;
+import { getClient } from '@sanwa-houkai-app/dataconnect';
 
 function ClientDetailContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const clientId = searchParams.get('id');
 
-  const [client, setClient] = useState<Client | null>(null);
+  const [client, setClient] = useState<ClientForDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,7 +28,7 @@ function ClientDetailContent() {
       try {
         const result = await getClient(dataConnect, { id: clientId });
         if (result.data.client) {
-          setClient(result.data.client);
+          setClient(result.data.client as ClientForDetail);
         } else {
           setError('利用者が見つかりません');
         }
@@ -68,383 +43,27 @@ function ClientDetailContent() {
     fetchClient();
   }, [clientId]);
 
-  const formatDate = (dateStr: string | null | undefined) => {
-    if (!dateStr) return '-';
-    const date = new Date(dateStr);
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
-  };
-
-  const calculateAge = (birthDate: string | null | undefined): string => {
-    if (!birthDate) return '-';
-    const birth = new Date(birthDate);
-    const today = new Date();
-    let age = today.getFullYear() - birth.getFullYear();
-    const monthDiff = today.getMonth() - birth.getMonth();
-    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-      age--;
-    }
-    return `${age}歳`;
-  };
-
-  const getFullAddress = (c: Client): string => {
-    const parts = [c.addressPrefecture, c.addressCity].filter(Boolean);
-    return parts.join(' ') || '-';
-  };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !client) {
-    return (
-      <>
-        <Box mb={2}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push('/clients')}
-          >
-            一覧に戻る
-          </Button>
-        </Box>
-        <Alert severity="error">{error || '利用者が見つかりません'}</Alert>
-      </>
-    );
-  }
-
   return (
-    <>
-      <Box mb={3}>
-        <Button
-          startIcon={<ArrowBackIcon />}
-          onClick={() => router.push('/clients')}
-        >
-          一覧に戻る
-        </Button>
-      </Box>
-
-      <Grid container spacing={3}>
-        {/* Basic Info */}
-        <Grid size={12}>
-          <Card>
-            <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
-                <Box>
-                  <Typography variant="h4" fontWeight={600} gutterBottom>
-                    {client.name}
-                  </Typography>
-                  {client.nameKana ? (
-                    <Typography variant="body1" color="text.secondary">
-                      {client.nameKana}
-                    </Typography>
-                  ) : null}
-                </Box>
-                {!client.isActive ? (
-                  <Chip
-                    label="非アクティブ"
-                    color="error"
-                    variant="outlined"
-                  />
-                ) : null}
-              </Box>
-
-              <Box display="flex" flexWrap="wrap" gap={2} mt={3}>
-                {client.careLevel?.name ? (
-                  <Chip
-                    label={client.careLevel.name}
-                    color="primary"
-                    variant="outlined"
-                  />
-                ) : null}
-                {client.gender ? (
-                  <Chip
-                    icon={<PersonIcon />}
-                    label={client.gender}
-                    variant="outlined"
-                  />
-                ) : null}
-                {client.birthDate ? (
-                  <Chip
-                    icon={<CakeIcon />}
-                    label={calculateAge(client.birthDate)}
-                    variant="outlined"
-                    color="success"
-                  />
-                ) : null}
-              </Box>
-
-              {client.birthDate ? (
-                <Box display="flex" alignItems="center" gap={1} mt={2}>
-                  <Typography variant="body2" color="text.secondary">
-                    生年月日:
-                  </Typography>
-                  <Typography variant="body1">
-                    {formatDate(client.birthDate)}
-                  </Typography>
-                </Box>
-              ) : null}
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Contact Info */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                連絡先
-              </Typography>
-
-              <Box display="flex" alignItems="flex-start" gap={1} mb={2}>
-                <LocationIcon color="action" sx={{ mt: 0.5 }} />
-                <Box>
-                  <Typography variant="body2" color="text.secondary">
-                    住所
-                  </Typography>
-                  <Typography variant="body1">
-                    {getFullAddress(client)}
-                  </Typography>
-                </Box>
-              </Box>
-
-              <Divider sx={{ my: 2 }} />
-
-              <Box display="flex" alignItems="center" justifyContent="space-between">
-                <Box display="flex" alignItems="flex-start" gap={1}>
-                  <PhoneIcon color="action" sx={{ mt: 0.5 }} />
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      電話番号
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.phone || '-'}
-                    </Typography>
-                  </Box>
-                </Box>
-                {client.phone ? (
-                  <Tooltip title="電話をかける">
-                    <IconButton
-                      color="primary"
-                      href={`tel:${client.phone}`}
-                      size="large"
-                    >
-                      <PhoneIcon />
-                    </IconButton>
-                  </Tooltip>
-                ) : null}
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Emergency Contact */}
-        {(client.emergencyName || client.emergencyPhone) ? (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card sx={{ height: '100%', bgcolor: 'warning.50' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <WarningIcon color="warning" />
-                  <Typography variant="h6">
-                    緊急連絡先
-                  </Typography>
-                </Box>
-
-                {client.emergencyName ? (
-                  <Box mb={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      氏名
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.emergencyName}
-                      {client.emergencyRelation ? (
-                        <Chip
-                          label={client.emergencyRelation}
-                          size="small"
-                          variant="outlined"
-                          sx={{ ml: 1 }}
-                        />
-                      ) : null}
-                    </Typography>
-                  </Box>
-                ) : null}
-
-                <Box display="flex" alignItems="center" justifyContent="space-between">
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      電話番号
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.emergencyPhone || '-'}
-                    </Typography>
-                  </Box>
-                  {client.emergencyPhone ? (
-                    <Tooltip title="電話をかける">
-                      <IconButton
-                        color="warning"
-                        href={`tel:${client.emergencyPhone}`}
-                        size="large"
-                      >
-                        <PhoneIcon />
-                      </IconButton>
-                    </Tooltip>
-                  ) : null}
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Care Info */}
-        {(client.careManager || client.careOffice) ? (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <AssignmentIcon color="action" />
-                  <Typography variant="h6">
-                    ケア情報
-                  </Typography>
-                </Box>
-
-                {client.careManager ? (
-                  <Box mb={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      ケアマネジャー
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.careManager}
-                    </Typography>
-                  </Box>
-                ) : null}
-
-                {client.careOffice ? (
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      事業所
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.careOffice}
-                    </Typography>
-                  </Box>
-                ) : null}
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Assessment */}
-        {(client.assessment || client.lastAssessmentDate) ? (
-          <Grid size={12}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  アセスメント
-                </Typography>
-
-                {client.lastAssessmentDate ? (
-                  <Box mb={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      最終評価日
-                    </Typography>
-                    <Typography variant="body1">
-                      {formatDate(client.lastAssessmentDate)}
-                    </Typography>
-                  </Box>
-                ) : null}
-
-                {client.assessment ? (
-                  <>
-                    <Divider sx={{ my: 2 }} />
-                    <Typography
-                      variant="body1"
-                      sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                    >
-                      {typeof client.assessment === 'string'
-                        ? client.assessment
-                        : JSON.stringify(client.assessment)}
-                    </Typography>
-                  </>
-                ) : null}
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Regular Services */}
-        {client.regularServices ? (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <EventRepeatIcon color="action" />
-                  <Typography variant="h6">
-                    定期サービス
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="body1"
-                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                >
-                  {typeof client.regularServices === 'string'
-                    ? client.regularServices
-                    : JSON.stringify(client.regularServices)}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Notes */}
-        {client.notes ? (
-          <Grid size={{ xs: 12, md: client.regularServices ? 6 : 12 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <NotesIcon color="action" />
-                  <Typography variant="h6">
-                    備考
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="body1"
-                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                >
-                  {client.notes}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Metadata */}
-        <Grid size={12}>
-          <Box display="flex" justifyContent="flex-end" gap={3}>
-            <Typography variant="caption" color="text.secondary">
-              登録: {new Date(client.createdAt).toLocaleString('ja-JP')}
-            </Typography>
-            {client.updatedAt !== client.createdAt ? (
-              <Typography variant="caption" color="text.secondary">
-                更新: {new Date(client.updatedAt).toLocaleString('ja-JP')}
-              </Typography>
-            ) : null}
-          </Box>
-        </Grid>
-      </Grid>
-    </>
+    <ClientDetailView
+      client={client}
+      loading={loading}
+      error={error}
+      onBack={() => router.push('/clients')}
+      showExtendedSections={true}
+    />
   );
 }
 
 export default function ClientDetailPage() {
   return (
     <MainLayout title="利用者詳細" showBackButton backHref="/clients">
-      <Suspense fallback={
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-          <CircularProgress />
-        </Box>
-      }>
+      <Suspense
+        fallback={
+          <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+            <CircularProgress />
+          </Box>
+        }
+      >
         <ClientDetailContent />
       </Suspense>
     </MainLayout>

--- a/web/src/app/demo/clients/detail/page.tsx
+++ b/web/src/app/demo/clients/detail/page.tsx
@@ -2,42 +2,17 @@
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import {
-  Box,
-  Typography,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Alert,
-  Button,
-  Grid,
-  Divider,
-  IconButton,
-  Tooltip,
-} from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  Phone as PhoneIcon,
-  LocationOn as LocationIcon,
-  Person as PersonIcon,
-  Cake as CakeIcon,
-  WarningAmber as WarningIcon,
-  Assignment as AssignmentIcon,
-  EventRepeat as EventRepeatIcon,
-  Notes as NotesIcon,
-} from '@mui/icons-material';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { ClientDetailView, ClientForDetail } from '@/components/clients';
 import { dataConnect } from '@/lib/firebase';
-import { demoGetClient, DemoGetClientData } from '@sanwa-houkai-app/dataconnect';
-
-type Client = NonNullable<DemoGetClientData['client']>;
+import { demoGetClient } from '@sanwa-houkai-app/dataconnect';
 
 function ClientDetailContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const clientId = searchParams.get('id');
 
-  const [client, setClient] = useState<Client | null>(null);
+  const [client, setClient] = useState<ClientForDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -52,7 +27,7 @@ function ClientDetailContent() {
       try {
         const result = await demoGetClient(dataConnect, { id: clientId });
         if (result.data.client) {
-          setClient(result.data.client);
+          setClient(result.data.client as ClientForDetail);
         } else {
           setError('利用者が見つかりません');
         }
@@ -67,320 +42,26 @@ function ClientDetailContent() {
     fetchClient();
   }, [clientId]);
 
-  const formatDate = (dateStr: string | null | undefined) => {
-    if (!dateStr) return '-';
-    const date = new Date(dateStr);
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
-  };
-
-  const calculateAge = (birthDate: string | null | undefined): string => {
-    if (!birthDate) return '-';
-    const birth = new Date(birthDate);
-    const today = new Date();
-    let age = today.getFullYear() - birth.getFullYear();
-    const monthDiff = today.getMonth() - birth.getMonth();
-    if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-      age--;
-    }
-    return `${age}歳`;
-  };
-
-  const getFullAddress = (c: Client): string => {
-    const parts = [c.addressPrefecture, c.addressCity].filter(Boolean);
-    return parts.join(' ') || '-';
-  };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !client) {
-    return (
-      <>
-        <Box mb={2}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push('/demo/clients')}
-          >
-            一覧に戻る
-          </Button>
-        </Box>
-        <Alert severity="error">{error || '利用者が見つかりません'}</Alert>
-      </>
-    );
-  }
-
   return (
-    <>
-      <Box mb={3}>
-        <Button
-          startIcon={<ArrowBackIcon />}
-          onClick={() => router.push('/demo/clients')}
-        >
-          一覧に戻る
-        </Button>
-      </Box>
-
-      <Grid container spacing={3}>
-        {/* Basic Info */}
-        <Grid size={12}>
-          <Card>
-            <CardContent>
-              <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
-                <Box>
-                  <Typography variant="h4" fontWeight={600} gutterBottom>
-                    {client.name}
-                  </Typography>
-                  {client.nameKana ? (
-                    <Typography variant="body1" color="text.secondary">
-                      {client.nameKana}
-                    </Typography>
-                  ) : null}
-                </Box>
-                {!client.isActive ? (
-                  <Chip
-                    label="非アクティブ"
-                    color="error"
-                    variant="outlined"
-                  />
-                ) : null}
-              </Box>
-
-              <Box display="flex" flexWrap="wrap" gap={2} mt={3}>
-                {client.careLevel?.name ? (
-                  <Chip
-                    label={client.careLevel.name}
-                    color="primary"
-                    variant="outlined"
-                  />
-                ) : null}
-                {client.gender ? (
-                  <Chip
-                    icon={<PersonIcon />}
-                    label={client.gender}
-                    variant="outlined"
-                  />
-                ) : null}
-                {client.birthDate ? (
-                  <Chip
-                    icon={<CakeIcon />}
-                    label={calculateAge(client.birthDate)}
-                    variant="outlined"
-                    color="success"
-                  />
-                ) : null}
-              </Box>
-
-              {client.birthDate ? (
-                <Box display="flex" alignItems="center" gap={1} mt={2}>
-                  <Typography variant="body2" color="text.secondary">
-                    生年月日:
-                  </Typography>
-                  <Typography variant="body1">
-                    {formatDate(client.birthDate)}
-                  </Typography>
-                </Box>
-              ) : null}
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Contact Info */}
-        <Grid size={{ xs: 12, md: 6 }}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                連絡先
-              </Typography>
-
-              <Box display="flex" alignItems="flex-start" gap={1} mb={2}>
-                <LocationIcon color="action" sx={{ mt: 0.5 }} />
-                <Box>
-                  <Typography variant="body2" color="text.secondary">
-                    住所
-                  </Typography>
-                  <Typography variant="body1">
-                    {getFullAddress(client)}
-                  </Typography>
-                </Box>
-              </Box>
-
-              <Divider sx={{ my: 2 }} />
-
-              <Box display="flex" alignItems="center" justifyContent="space-between">
-                <Box display="flex" alignItems="flex-start" gap={1}>
-                  <PhoneIcon color="action" sx={{ mt: 0.5 }} />
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      電話番号
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.phone || '-'}
-                    </Typography>
-                  </Box>
-                </Box>
-                {client.phone ? (
-                  <Tooltip title="電話をかける">
-                    <IconButton
-                      color="primary"
-                      href={`tel:${client.phone}`}
-                      size="large"
-                    >
-                      <PhoneIcon />
-                    </IconButton>
-                  </Tooltip>
-                ) : null}
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Emergency Contact */}
-        {(client.emergencyName || client.emergencyPhone) ? (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card sx={{ height: '100%', bgcolor: 'warning.50' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <WarningIcon color="warning" />
-                  <Typography variant="h6">
-                    緊急連絡先
-                  </Typography>
-                </Box>
-
-                {client.emergencyName ? (
-                  <Box mb={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      氏名
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.emergencyName}
-                      {client.emergencyRelation ? (
-                        <Chip
-                          label={client.emergencyRelation}
-                          size="small"
-                          variant="outlined"
-                          sx={{ ml: 1 }}
-                        />
-                      ) : null}
-                    </Typography>
-                  </Box>
-                ) : null}
-
-                <Box display="flex" alignItems="center" justifyContent="space-between">
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      電話番号
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.emergencyPhone || '-'}
-                    </Typography>
-                  </Box>
-                  {client.emergencyPhone ? (
-                    <Tooltip title="電話をかける">
-                      <IconButton
-                        color="warning"
-                        href={`tel:${client.emergencyPhone}`}
-                        size="large"
-                      >
-                        <PhoneIcon />
-                      </IconButton>
-                    </Tooltip>
-                  ) : null}
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Care Info */}
-        {(client.careManager || client.careOffice) ? (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <AssignmentIcon color="action" />
-                  <Typography variant="h6">
-                    ケア情報
-                  </Typography>
-                </Box>
-
-                {client.careManager ? (
-                  <Box mb={2}>
-                    <Typography variant="body2" color="text.secondary">
-                      ケアマネジャー
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.careManager}
-                    </Typography>
-                  </Box>
-                ) : null}
-
-                {client.careOffice ? (
-                  <Box>
-                    <Typography variant="body2" color="text.secondary">
-                      事業所
-                    </Typography>
-                    <Typography variant="body1">
-                      {client.careOffice}
-                    </Typography>
-                  </Box>
-                ) : null}
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Notes */}
-        {client.notes ? (
-          <Grid size={12}>
-            <Card>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <NotesIcon color="action" />
-                  <Typography variant="h6">
-                    備考
-                  </Typography>
-                </Box>
-                <Typography
-                  variant="body1"
-                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                >
-                  {client.notes}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        ) : null}
-
-        {/* Metadata */}
-        <Grid size={12}>
-          <Box display="flex" justifyContent="flex-end" gap={3}>
-            <Typography variant="caption" color="text.secondary">
-              登録: {new Date(client.createdAt).toLocaleString('ja-JP')}
-            </Typography>
-            {client.updatedAt !== client.createdAt ? (
-              <Typography variant="caption" color="text.secondary">
-                更新: {new Date(client.updatedAt).toLocaleString('ja-JP')}
-              </Typography>
-            ) : null}
-          </Box>
-        </Grid>
-      </Grid>
-    </>
+    <ClientDetailView
+      client={client}
+      loading={loading}
+      error={error}
+      onBack={() => router.push('/demo/clients')}
+      showExtendedSections={true}
+    />
   );
 }
 
 export default function DemoClientDetailPage() {
   return (
-    <Suspense fallback={
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    }>
+    <Suspense
+      fallback={
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      }
+    >
       <Typography variant="h5" sx={{ mb: 3 }}>
         利用者詳細
       </Typography>

--- a/web/src/app/demo/records/detail/page.tsx
+++ b/web/src/app/demo/records/detail/page.tsx
@@ -2,49 +2,17 @@
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import {
-  Box,
-  Typography,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Alert,
-  Button,
-  Grid,
-  Divider,
-  Paper,
-} from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  Person as PersonIcon,
-  AccessTime as AccessTimeIcon,
-  CalendarToday as CalendarIcon,
-  SmartToy as AiIcon,
-} from '@mui/icons-material';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { RecordDetailView, VisitRecordForDetail } from '@/components/records';
 import { dataConnect } from '@/lib/firebase';
-import { demoGetVisitRecord, DemoGetVisitRecordData } from '@sanwa-houkai-app/dataconnect';
-
-type VisitRecord = NonNullable<DemoGetVisitRecordData['visitRecord']>;
-
-interface Service {
-  typeId: string;
-  typeName: string;
-  items: { id: string; name: string }[];
-}
-
-interface Vitals {
-  pulse?: number;
-  bloodPressureHigh?: number;
-  bloodPressureLow?: number;
-}
+import { demoGetVisitRecord } from '@sanwa-houkai-app/dataconnect';
 
 function RecordDetailContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const recordId = searchParams.get('id');
 
-  const [record, setRecord] = useState<VisitRecord | null>(null);
+  const [record, setRecord] = useState<VisitRecordForDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,7 +27,7 @@ function RecordDetailContent() {
       try {
         const result = await demoGetVisitRecord(dataConnect, { id: recordId });
         if (result.data.visitRecord) {
-          setRecord(result.data.visitRecord);
+          setRecord(result.data.visitRecord as VisitRecordForDetail);
         } else {
           setError('記録が見つかりません');
         }
@@ -74,242 +42,26 @@ function RecordDetailContent() {
     fetchRecord();
   }, [recordId]);
 
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr);
-    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 (${weekdays[date.getDay()]})`;
-  };
-
-  const formatTimeRange = (start: string, end: string) => {
-    return `${start.slice(0, 5)} - ${end.slice(0, 5)}`;
-  };
-
-  const parseServices = (servicesData: unknown): Service[] => {
-    if (!servicesData) return [];
-    try {
-      if (typeof servicesData === 'string') {
-        return JSON.parse(servicesData);
-      }
-      return servicesData as Service[];
-    } catch {
-      return [];
-    }
-  };
-
-  const parseVitals = (vitalsData: unknown): Vitals | null => {
-    if (!vitalsData) return null;
-    try {
-      if (typeof vitalsData === 'string') {
-        return JSON.parse(vitalsData);
-      }
-      return vitalsData as Vitals;
-    } catch {
-      return null;
-    }
-  };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !record) {
-    return (
-      <>
-        <Box mb={2}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push('/demo/records')}
-          >
-            一覧に戻る
-          </Button>
-        </Box>
-        <Alert severity="error">{error || '記録が見つかりません'}</Alert>
-      </>
-    );
-  }
-
-  const services = parseServices(record.services);
-  const vitals = parseVitals(record.vitals);
-
   return (
-    <>
-      <Box mb={3}>
-        <Button
-          startIcon={<ArrowBackIcon />}
-          onClick={() => router.push('/demo/records')}
-        >
-          一覧に戻る
-        </Button>
-      </Box>
-
-      <Grid container spacing={3}>
-        {/* Basic Info */}
-        <Grid size={12}>
-          <Card>
-            <CardContent>
-              <Typography variant="h5" fontWeight={600} gutterBottom>
-                {record.client.name}
-              </Typography>
-              <Box display="flex" flexWrap="wrap" gap={3} mt={2}>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <CalendarIcon color="action" />
-                  <Typography>{formatDate(record.visitDate)}</Typography>
-                </Box>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <AccessTimeIcon color="action" />
-                  <Typography>{formatTimeRange(record.startTime, record.endTime)}</Typography>
-                </Box>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <PersonIcon color="action" />
-                  <Chip label={record.staff.name} variant="outlined" />
-                </Box>
-                {record.visitReason && (
-                  <Chip label={record.visitReason.name} color="primary" variant="outlined" />
-                )}
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Vitals */}
-        {vitals && (vitals.pulse || vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  バイタル
-                </Typography>
-                <Box display="flex" gap={3} flexWrap="wrap">
-                  {vitals.pulse && (
-                    <Paper
-                      variant="outlined"
-                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
-                    >
-                      <Typography variant="body2" color="text.secondary">
-                        脈拍
-                      </Typography>
-                      <Typography variant="h5" fontWeight={600}>
-                        {vitals.pulse}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        bpm
-                      </Typography>
-                    </Paper>
-                  )}
-                  {(vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
-                    <Paper
-                      variant="outlined"
-                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
-                    >
-                      <Typography variant="body2" color="text.secondary">
-                        血圧
-                      </Typography>
-                      <Typography variant="h5" fontWeight={600}>
-                        {vitals.bloodPressureHigh || '-'}/{vitals.bloodPressureLow || '-'}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        mmHg
-                      </Typography>
-                    </Paper>
-                  )}
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Services */}
-        {services.length > 0 && (
-          <Grid size={{ xs: 12, md: vitals ? 8 : 12 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  サービス内容
-                </Typography>
-                {services.map((service, index) => (
-                  <Box key={service.typeId} mb={index < services.length - 1 ? 2 : 0}>
-                    <Typography
-                      variant="subtitle2"
-                      color="text.secondary"
-                      gutterBottom
-                    >
-                      {service.typeName}
-                    </Typography>
-                    <Box display="flex" flexWrap="wrap" gap={1}>
-                      {service.items.map((item) => (
-                        <Chip
-                          key={item.id}
-                          label={item.name}
-                          size="small"
-                          sx={{ bgcolor: 'primary.50' }}
-                        />
-                      ))}
-                    </Box>
-                    {index < services.length - 1 && <Divider sx={{ mt: 2 }} />}
-                  </Box>
-                ))}
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Notes */}
-        {record.notes && (
-          <Grid size={12}>
-            <Card>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <Typography variant="h6">特記事項</Typography>
-                  {record.aiGenerated && (
-                    <Chip
-                      icon={<AiIcon />}
-                      label="AI生成"
-                      size="small"
-                      color="secondary"
-                      variant="outlined"
-                    />
-                  )}
-                </Box>
-                <Typography
-                  variant="body1"
-                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                >
-                  {record.notes}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Metadata */}
-        <Grid size={12}>
-          <Box display="flex" justifyContent="flex-end" gap={3}>
-            <Typography variant="caption" color="text.secondary">
-              作成: {new Date(record.createdAt).toLocaleString('ja-JP')}
-            </Typography>
-            {record.updatedAt !== record.createdAt && (
-              <Typography variant="caption" color="text.secondary">
-                更新: {new Date(record.updatedAt).toLocaleString('ja-JP')}
-              </Typography>
-            )}
-          </Box>
-        </Grid>
-      </Grid>
-    </>
+    <RecordDetailView
+      record={record}
+      loading={loading}
+      error={error}
+      onBack={() => router.push('/demo/records')}
+      showExtendedSections={true}
+    />
   );
 }
 
 export default function DemoRecordDetailPage() {
   return (
-    <Suspense fallback={
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    }>
+    <Suspense
+      fallback={
+        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+          <CircularProgress />
+        </Box>
+      }
+    >
       <Typography variant="h5" sx={{ mb: 3 }}>
         記録詳細
       </Typography>

--- a/web/src/app/records/detail/page.tsx
+++ b/web/src/app/records/detail/page.tsx
@@ -2,50 +2,18 @@
 
 import { useState, useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import {
-  Box,
-  Typography,
-  Card,
-  CardContent,
-  Chip,
-  CircularProgress,
-  Alert,
-  Button,
-  Grid,
-  Divider,
-  Paper,
-} from '@mui/material';
-import {
-  ArrowBack as ArrowBackIcon,
-  Person as PersonIcon,
-  AccessTime as AccessTimeIcon,
-  CalendarToday as CalendarIcon,
-  SmartToy as AiIcon,
-} from '@mui/icons-material';
+import { Box, CircularProgress } from '@mui/material';
 import { MainLayout } from '@/components/layout';
+import { RecordDetailView, VisitRecordForDetail } from '@/components/records';
 import { dataConnect } from '@/lib/firebase';
-import { getVisitRecord, GetVisitRecordData } from '@sanwa-houkai-app/dataconnect';
-
-type VisitRecord = NonNullable<GetVisitRecordData['visitRecord']>;
-
-interface Service {
-  typeId: string;
-  typeName: string;
-  items: { id: string; name: string }[];
-}
-
-interface Vitals {
-  pulse?: number;
-  bloodPressureHigh?: number;
-  bloodPressureLow?: number;
-}
+import { getVisitRecord } from '@sanwa-houkai-app/dataconnect';
 
 function RecordDetailContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const recordId = searchParams.get('id');
 
-  const [record, setRecord] = useState<VisitRecord | null>(null);
+  const [record, setRecord] = useState<VisitRecordForDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -60,7 +28,7 @@ function RecordDetailContent() {
       try {
         const result = await getVisitRecord(dataConnect, { id: recordId });
         if (result.data.visitRecord) {
-          setRecord(result.data.visitRecord);
+          setRecord(result.data.visitRecord as VisitRecordForDetail);
         } else {
           setError('記録が見つかりません');
         }
@@ -75,306 +43,27 @@ function RecordDetailContent() {
     fetchRecord();
   }, [recordId]);
 
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr);
-    const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 (${weekdays[date.getDay()]})`;
-  };
-
-  const formatTimeRange = (start: string, end: string) => {
-    return `${start.slice(0, 5)} - ${end.slice(0, 5)}`;
-  };
-
-  const parseServices = (servicesData: unknown): Service[] => {
-    if (!servicesData) return [];
-    try {
-      if (typeof servicesData === 'string') {
-        return JSON.parse(servicesData);
-      }
-      return servicesData as Service[];
-    } catch {
-      return [];
-    }
-  };
-
-  const parseVitals = (vitalsData: unknown): Vitals | null => {
-    if (!vitalsData) return null;
-    try {
-      if (typeof vitalsData === 'string') {
-        return JSON.parse(vitalsData);
-      }
-      return vitalsData as Vitals;
-    } catch {
-      return null;
-    }
-  };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
-  }
-
-  if (error || !record) {
-    return (
-      <>
-        <Box mb={2}>
-          <Button
-            startIcon={<ArrowBackIcon />}
-            onClick={() => router.push('/records')}
-          >
-            一覧に戻る
-          </Button>
-        </Box>
-        <Alert severity="error">{error || '記録が見つかりません'}</Alert>
-      </>
-    );
-  }
-
-  const services = parseServices(record.services);
-  const vitals = parseVitals(record.vitals);
-
   return (
-    <>
-      <Box mb={3}>
-        <Button
-          startIcon={<ArrowBackIcon />}
-          onClick={() => router.push('/records')}
-        >
-          一覧に戻る
-        </Button>
-      </Box>
-
-      <Grid container spacing={3}>
-        {/* Basic Info */}
-        <Grid size={12}>
-          <Card>
-            <CardContent>
-              <Typography variant="h5" fontWeight={600} gutterBottom>
-                {record.client.name}
-              </Typography>
-              <Box display="flex" flexWrap="wrap" gap={3} mt={2}>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <CalendarIcon color="action" />
-                  <Typography>{formatDate(record.visitDate)}</Typography>
-                </Box>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <AccessTimeIcon color="action" />
-                  <Typography>{formatTimeRange(record.startTime, record.endTime)}</Typography>
-                </Box>
-                <Box display="flex" alignItems="center" gap={1}>
-                  <PersonIcon color="action" />
-                  <Chip label={record.staff.name} variant="outlined" />
-                </Box>
-                {record.visitReason && (
-                  <Chip label={record.visitReason.name} color="primary" variant="outlined" />
-                )}
-              </Box>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        {/* Vitals */}
-        {vitals && (vitals.pulse || vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  バイタル
-                </Typography>
-                <Box display="flex" gap={3} flexWrap="wrap">
-                  {vitals.pulse && (
-                    <Paper
-                      variant="outlined"
-                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
-                    >
-                      <Typography variant="body2" color="text.secondary">
-                        脈拍
-                      </Typography>
-                      <Typography variant="h5" fontWeight={600}>
-                        {vitals.pulse}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        bpm
-                      </Typography>
-                    </Paper>
-                  )}
-                  {(vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
-                    <Paper
-                      variant="outlined"
-                      sx={{ p: 2, textAlign: 'center', minWidth: 100 }}
-                    >
-                      <Typography variant="body2" color="text.secondary">
-                        血圧
-                      </Typography>
-                      <Typography variant="h5" fontWeight={600}>
-                        {vitals.bloodPressureHigh || '-'}/{vitals.bloodPressureLow || '-'}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary">
-                        mmHg
-                      </Typography>
-                    </Paper>
-                  )}
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Services */}
-        {services.length > 0 && (
-          <Grid size={{ xs: 12, md: vitals ? 8 : 12 }}>
-            <Card sx={{ height: '100%' }}>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  サービス内容
-                </Typography>
-                {services.map((service, index) => (
-                  <Box key={service.typeId} mb={index < services.length - 1 ? 2 : 0}>
-                    <Typography
-                      variant="subtitle2"
-                      color="text.secondary"
-                      gutterBottom
-                    >
-                      {service.typeName}
-                    </Typography>
-                    <Box display="flex" flexWrap="wrap" gap={1}>
-                      {service.items.map((item) => (
-                        <Chip
-                          key={item.id}
-                          label={item.name}
-                          size="small"
-                          sx={{ bgcolor: 'primary.50' }}
-                        />
-                      ))}
-                    </Box>
-                    {index < services.length - 1 && <Divider sx={{ mt: 2 }} />}
-                  </Box>
-                ))}
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Notes */}
-        {record.notes && (
-          <Grid size={12}>
-            <Card>
-              <CardContent>
-                <Box display="flex" alignItems="center" gap={1} mb={2}>
-                  <Typography variant="h6">特記事項</Typography>
-                  {record.aiGenerated && (
-                    <Chip
-                      icon={<AiIcon />}
-                      label="AI生成"
-                      size="small"
-                      color="secondary"
-                      variant="outlined"
-                    />
-                  )}
-                </Box>
-                <Typography
-                  variant="body1"
-                  sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}
-                >
-                  {record.notes}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Satisfaction */}
-        {record.satisfaction && (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  満足度
-                </Typography>
-                <Typography variant="body1" fontWeight={500}>
-                  {record.satisfaction}
-                </Typography>
-                {record.satisfactionReason && (
-                  <Typography variant="body2" color="text.secondary" mt={1}>
-                    {record.satisfactionReason}
-                  </Typography>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Condition Change */}
-        {record.conditionChange && (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  状態の変化
-                </Typography>
-                <Typography variant="body1" fontWeight={500}>
-                  {record.conditionChange}
-                </Typography>
-                {record.conditionChangeDetail && (
-                  <Typography variant="body2" color="text.secondary" mt={1}>
-                    {record.conditionChangeDetail}
-                  </Typography>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Service Change */}
-        {record.serviceChangeNeeded && (
-          <Grid size={{ xs: 12, md: 6 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="h6" gutterBottom>
-                  サービス変更の必要性
-                </Typography>
-                <Typography variant="body1" fontWeight={500}>
-                  {record.serviceChangeNeeded}
-                </Typography>
-                {record.serviceChangeDetail && (
-                  <Typography variant="body2" color="text.secondary" mt={1}>
-                    {record.serviceChangeDetail}
-                  </Typography>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
-        )}
-
-        {/* Metadata */}
-        <Grid size={12}>
-          <Box display="flex" justifyContent="flex-end" gap={3}>
-            <Typography variant="caption" color="text.secondary">
-              作成: {new Date(record.createdAt).toLocaleString('ja-JP')}
-            </Typography>
-            {record.updatedAt !== record.createdAt && (
-              <Typography variant="caption" color="text.secondary">
-                更新: {new Date(record.updatedAt).toLocaleString('ja-JP')}
-              </Typography>
-            )}
-          </Box>
-        </Grid>
-      </Grid>
-    </>
+    <RecordDetailView
+      record={record}
+      loading={loading}
+      error={error}
+      onBack={() => router.push('/records')}
+      showExtendedSections={true}
+    />
   );
 }
 
 export default function RecordDetailPage() {
   return (
     <MainLayout title="記録詳細" showBackButton backHref="/records">
-      <Suspense fallback={
-        <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-          <CircularProgress />
-        </Box>
-      }>
+      <Suspense
+        fallback={
+          <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+            <CircularProgress />
+          </Box>
+        }
+      >
         <RecordDetailContent />
       </Suspense>
     </MainLayout>

--- a/web/src/components/clients/ClientDetailView.tsx
+++ b/web/src/components/clients/ClientDetailView.tsx
@@ -1,0 +1,396 @@
+'use client';
+
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Alert,
+  Button,
+  Grid,
+  Divider,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Phone as PhoneIcon,
+  LocationOn as LocationIcon,
+  Person as PersonIcon,
+  Cake as CakeIcon,
+  WarningAmber as WarningIcon,
+  Assignment as AssignmentIcon,
+  EventRepeat as EventRepeatIcon,
+  Notes as NotesIcon,
+} from '@mui/icons-material';
+import { formatDateJapanese } from '@/utils/formatters';
+
+/**
+ * 利用者データの型定義（本番/デモ共通）
+ */
+export interface ClientForDetail {
+  name: string;
+  nameKana?: string | null;
+  isActive: boolean;
+  gender?: string | null;
+  birthDate?: string | null;
+  careLevel?: { name: string } | null;
+  addressPrefecture?: string | null;
+  addressCity?: string | null;
+  phone?: string | null;
+  emergencyName?: string | null;
+  emergencyPhone?: string | null;
+  emergencyRelation?: string | null;
+  careManager?: string | null;
+  careOffice?: string | null;
+  assessment?: string | null;
+  lastAssessmentDate?: string | null;
+  regularServices?: string | null;
+  notes?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * ClientDetailViewのプロパティ
+ */
+export interface ClientDetailViewProps {
+  /** 利用者データ */
+  client: ClientForDetail | null;
+  /** ローディング状態 */
+  loading: boolean;
+  /** エラーメッセージ */
+  error: string | null;
+  /** 戻るボタンクリック時のハンドラ */
+  onBack: () => void;
+  /** 拡張セクション（アセスメント、定期サービス）を表示するか */
+  showExtendedSections?: boolean;
+}
+
+/**
+ * 年齢計算
+ */
+function calculateAge(birthDate: string | null | undefined): string {
+  if (!birthDate) return '-';
+  const birth = new Date(birthDate);
+  const today = new Date();
+  let age = today.getFullYear() - birth.getFullYear();
+  const monthDiff = today.getMonth() - birth.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+  return `${age}歳`;
+}
+
+/**
+ * 住所フォーマット
+ */
+function getFullAddress(client: ClientForDetail): string {
+  const parts = [client.addressPrefecture, client.addressCity].filter(Boolean);
+  return parts.join(' ') || '-';
+}
+
+/**
+ * 利用者詳細表示コンポーネント
+ * 本番/デモで共通使用
+ */
+export function ClientDetailView({
+  client,
+  loading,
+  error,
+  onBack,
+  showExtendedSections = true,
+}: ClientDetailViewProps) {
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !client) {
+    return (
+      <>
+        <Box mb={2}>
+          <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+            一覧に戻る
+          </Button>
+        </Box>
+        <Alert severity="error">{error || '利用者が見つかりません'}</Alert>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Box mb={3}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          一覧に戻る
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {/* Basic Info */}
+        <Grid size={12}>
+          <Card>
+            <CardContent>
+              <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
+                <Box>
+                  <Typography variant="h4" fontWeight={600} gutterBottom>
+                    {client.name}
+                  </Typography>
+                  {client.nameKana ? (
+                    <Typography variant="body1" color="text.secondary">
+                      {client.nameKana}
+                    </Typography>
+                  ) : null}
+                </Box>
+                {!client.isActive ? (
+                  <Chip label="非アクティブ" color="error" variant="outlined" />
+                ) : null}
+              </Box>
+
+              <Box display="flex" flexWrap="wrap" gap={2} mt={3}>
+                {client.careLevel?.name ? (
+                  <Chip label={client.careLevel.name} color="primary" variant="outlined" />
+                ) : null}
+                {client.gender ? (
+                  <Chip icon={<PersonIcon />} label={client.gender} variant="outlined" />
+                ) : null}
+                {client.birthDate ? (
+                  <Chip
+                    icon={<CakeIcon />}
+                    label={calculateAge(client.birthDate)}
+                    variant="outlined"
+                    color="success"
+                  />
+                ) : null}
+              </Box>
+
+              {client.birthDate ? (
+                <Box display="flex" alignItems="center" gap={1} mt={2}>
+                  <Typography variant="body2" color="text.secondary">
+                    生年月日:
+                  </Typography>
+                  <Typography variant="body1">{formatDateJapanese(client.birthDate)}</Typography>
+                </Box>
+              ) : null}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Contact Info */}
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                連絡先
+              </Typography>
+
+              <Box display="flex" alignItems="flex-start" gap={1} mb={2}>
+                <LocationIcon color="action" sx={{ mt: 0.5 }} />
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    住所
+                  </Typography>
+                  <Typography variant="body1">{getFullAddress(client)}</Typography>
+                </Box>
+              </Box>
+
+              <Divider sx={{ my: 2 }} />
+
+              <Box display="flex" alignItems="center" justifyContent="space-between">
+                <Box display="flex" alignItems="flex-start" gap={1}>
+                  <PhoneIcon color="action" sx={{ mt: 0.5 }} />
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      電話番号
+                    </Typography>
+                    <Typography variant="body1">{client.phone || '-'}</Typography>
+                  </Box>
+                </Box>
+                {client.phone ? (
+                  <Tooltip title="電話をかける">
+                    <IconButton color="primary" href={`tel:${client.phone}`} size="large">
+                      <PhoneIcon />
+                    </IconButton>
+                  </Tooltip>
+                ) : null}
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Emergency Contact */}
+        {client.emergencyName || client.emergencyPhone ? (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card sx={{ height: '100%', bgcolor: 'warning.50' }}>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <WarningIcon color="warning" />
+                  <Typography variant="h6">緊急連絡先</Typography>
+                </Box>
+
+                {client.emergencyName ? (
+                  <Box mb={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      氏名
+                    </Typography>
+                    <Typography variant="body1">
+                      {client.emergencyName}
+                      {client.emergencyRelation ? (
+                        <Chip
+                          label={client.emergencyRelation}
+                          size="small"
+                          variant="outlined"
+                          sx={{ ml: 1 }}
+                        />
+                      ) : null}
+                    </Typography>
+                  </Box>
+                ) : null}
+
+                <Box display="flex" alignItems="center" justifyContent="space-between">
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      電話番号
+                    </Typography>
+                    <Typography variant="body1">{client.emergencyPhone || '-'}</Typography>
+                  </Box>
+                  {client.emergencyPhone ? (
+                    <Tooltip title="電話をかける">
+                      <IconButton color="warning" href={`tel:${client.emergencyPhone}`} size="large">
+                        <PhoneIcon />
+                      </IconButton>
+                    </Tooltip>
+                  ) : null}
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+
+        {/* Care Info */}
+        {client.careManager || client.careOffice ? (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <AssignmentIcon color="action" />
+                  <Typography variant="h6">ケア情報</Typography>
+                </Box>
+
+                {client.careManager ? (
+                  <Box mb={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      ケアマネジャー
+                    </Typography>
+                    <Typography variant="body1">{client.careManager}</Typography>
+                  </Box>
+                ) : null}
+
+                {client.careOffice ? (
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      事業所
+                    </Typography>
+                    <Typography variant="body1">{client.careOffice}</Typography>
+                  </Box>
+                ) : null}
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+
+        {/* Assessment (Extended Section) */}
+        {showExtendedSections && (client.assessment || client.lastAssessmentDate) ? (
+          <Grid size={12}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  アセスメント
+                </Typography>
+
+                {client.lastAssessmentDate ? (
+                  <Box mb={2}>
+                    <Typography variant="body2" color="text.secondary">
+                      最終評価日
+                    </Typography>
+                    <Typography variant="body1">
+                      {formatDateJapanese(client.lastAssessmentDate)}
+                    </Typography>
+                  </Box>
+                ) : null}
+
+                {client.assessment ? (
+                  <>
+                    <Divider sx={{ my: 2 }} />
+                    <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+                      {client.assessment}
+                    </Typography>
+                  </>
+                ) : null}
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+
+        {/* Regular Services (Extended Section) */}
+        {showExtendedSections && client.regularServices ? (
+          <Grid size={{ xs: 12, md: 6 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <EventRepeatIcon color="action" />
+                  <Typography variant="h6">定期サービス</Typography>
+                </Box>
+                <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+                  {client.regularServices}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+
+        {/* Notes */}
+        {client.notes ? (
+          <Grid
+            size={{
+              xs: 12,
+              md: showExtendedSections && client.regularServices ? 6 : 12,
+            }}
+          >
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <NotesIcon color="action" />
+                  <Typography variant="h6">備考</Typography>
+                </Box>
+                <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+                  {client.notes}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ) : null}
+
+        {/* Metadata */}
+        <Grid size={12}>
+          <Box display="flex" justifyContent="flex-end" gap={3}>
+            <Typography variant="caption" color="text.secondary">
+              登録: {new Date(client.createdAt).toLocaleString('ja-JP')}
+            </Typography>
+            {client.updatedAt !== client.createdAt ? (
+              <Typography variant="caption" color="text.secondary">
+                更新: {new Date(client.updatedAt).toLocaleString('ja-JP')}
+              </Typography>
+            ) : null}
+          </Box>
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/web/src/components/clients/index.ts
+++ b/web/src/components/clients/index.ts
@@ -1,0 +1,2 @@
+export { ClientDetailView } from './ClientDetailView';
+export type { ClientDetailViewProps, ClientForDetail } from './ClientDetailView';

--- a/web/src/components/records/RecordDetailView.tsx
+++ b/web/src/components/records/RecordDetailView.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import {
+  Box,
+  Typography,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Alert,
+  Button,
+  Grid,
+  Divider,
+  Paper,
+} from '@mui/material';
+import {
+  ArrowBack as ArrowBackIcon,
+  Person as PersonIcon,
+  AccessTime as AccessTimeIcon,
+  CalendarToday as CalendarIcon,
+  SmartToy as AiIcon,
+} from '@mui/icons-material';
+import { formatDateJapaneseWithWeekday, formatTimeRange } from '@/utils/formatters';
+
+/**
+ * サービス情報の型定義
+ */
+interface Service {
+  typeId: string;
+  typeName: string;
+  items: { id: string; name: string }[];
+}
+
+/**
+ * バイタル情報の型定義
+ */
+interface Vitals {
+  pulse?: number;
+  bloodPressureHigh?: number;
+  bloodPressureLow?: number;
+}
+
+/**
+ * 訪問記録の型定義（本番/デモ共通）
+ */
+export interface VisitRecordForDetail {
+  client: { name: string };
+  staff: { name: string };
+  visitDate: string;
+  startTime: string;
+  endTime: string;
+  visitReason?: { name: string } | null;
+  vitals?: unknown;
+  services?: unknown;
+  notes?: string | null;
+  aiGenerated?: boolean | null;
+  satisfaction?: string | null;
+  satisfactionReason?: string | null;
+  conditionChange?: string | null;
+  conditionChangeDetail?: string | null;
+  serviceChangeNeeded?: string | null;
+  serviceChangeDetail?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * RecordDetailViewのプロパティ
+ */
+export interface RecordDetailViewProps {
+  /** 訪問記録データ */
+  record: VisitRecordForDetail | null;
+  /** ローディング状態 */
+  loading: boolean;
+  /** エラーメッセージ */
+  error: string | null;
+  /** 戻るボタンクリック時のハンドラ */
+  onBack: () => void;
+  /** 追加セクション（満足度、状態変化など）を表示するか */
+  showExtendedSections?: boolean;
+}
+
+/**
+ * サービスデータをパース
+ */
+function parseServices(servicesData: unknown): Service[] {
+  if (!servicesData) return [];
+  try {
+    if (typeof servicesData === 'string') {
+      return JSON.parse(servicesData);
+    }
+    return servicesData as Service[];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * バイタルデータをパース
+ */
+function parseVitals(vitalsData: unknown): Vitals | null {
+  if (!vitalsData) return null;
+  try {
+    if (typeof vitalsData === 'string') {
+      return JSON.parse(vitalsData);
+    }
+    return vitalsData as Vitals;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 訪問記録詳細表示コンポーネント
+ * 本番/デモで共通使用
+ */
+export function RecordDetailView({
+  record,
+  loading,
+  error,
+  onBack,
+  showExtendedSections = true,
+}: RecordDetailViewProps) {
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !record) {
+    return (
+      <>
+        <Box mb={2}>
+          <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+            一覧に戻る
+          </Button>
+        </Box>
+        <Alert severity="error">{error || '記録が見つかりません'}</Alert>
+      </>
+    );
+  }
+
+  const services = parseServices(record.services);
+  const vitals = parseVitals(record.vitals);
+
+  return (
+    <>
+      <Box mb={3}>
+        <Button startIcon={<ArrowBackIcon />} onClick={onBack}>
+          一覧に戻る
+        </Button>
+      </Box>
+
+      <Grid container spacing={3}>
+        {/* Basic Info */}
+        <Grid size={12}>
+          <Card>
+            <CardContent>
+              <Typography variant="h5" fontWeight={600} gutterBottom>
+                {record.client.name}
+              </Typography>
+              <Box display="flex" flexWrap="wrap" gap={3} mt={2}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <CalendarIcon color="action" />
+                  <Typography>{formatDateJapaneseWithWeekday(record.visitDate)}</Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <AccessTimeIcon color="action" />
+                  <Typography>{formatTimeRange(record.startTime, record.endTime)}</Typography>
+                </Box>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <PersonIcon color="action" />
+                  <Chip label={record.staff.name} variant="outlined" />
+                </Box>
+                {record.visitReason && (
+                  <Chip label={record.visitReason.name} color="primary" variant="outlined" />
+                )}
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* Vitals */}
+        {vitals && (vitals.pulse || vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+          <Grid size={{ xs: 12, md: 4 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  バイタル
+                </Typography>
+                <Box display="flex" gap={3} flexWrap="wrap">
+                  {vitals.pulse && (
+                    <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', minWidth: 100 }}>
+                      <Typography variant="body2" color="text.secondary">
+                        脈拍
+                      </Typography>
+                      <Typography variant="h5" fontWeight={600}>
+                        {vitals.pulse}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        bpm
+                      </Typography>
+                    </Paper>
+                  )}
+                  {(vitals.bloodPressureHigh || vitals.bloodPressureLow) && (
+                    <Paper variant="outlined" sx={{ p: 2, textAlign: 'center', minWidth: 100 }}>
+                      <Typography variant="body2" color="text.secondary">
+                        血圧
+                      </Typography>
+                      <Typography variant="h5" fontWeight={600}>
+                        {vitals.bloodPressureHigh || '-'}/{vitals.bloodPressureLow || '-'}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        mmHg
+                      </Typography>
+                    </Paper>
+                  )}
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Services */}
+        {services.length > 0 && (
+          <Grid size={{ xs: 12, md: vitals ? 8 : 12 }}>
+            <Card sx={{ height: '100%' }}>
+              <CardContent>
+                <Typography variant="h6" gutterBottom>
+                  サービス内容
+                </Typography>
+                {services.map((service, index) => (
+                  <Box key={service.typeId} mb={index < services.length - 1 ? 2 : 0}>
+                    <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                      {service.typeName}
+                    </Typography>
+                    <Box display="flex" flexWrap="wrap" gap={1}>
+                      {service.items.map((item) => (
+                        <Chip
+                          key={item.id}
+                          label={item.name}
+                          size="small"
+                          sx={{ bgcolor: 'primary.50' }}
+                        />
+                      ))}
+                    </Box>
+                    {index < services.length - 1 && <Divider sx={{ mt: 2 }} />}
+                  </Box>
+                ))}
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Notes */}
+        {record.notes && (
+          <Grid size={12}>
+            <Card>
+              <CardContent>
+                <Box display="flex" alignItems="center" gap={1} mb={2}>
+                  <Typography variant="h6">特記事項</Typography>
+                  {record.aiGenerated && (
+                    <Chip
+                      icon={<AiIcon />}
+                      label="AI生成"
+                      size="small"
+                      color="secondary"
+                      variant="outlined"
+                    />
+                  )}
+                </Box>
+                <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap', lineHeight: 1.8 }}>
+                  {record.notes}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        )}
+
+        {/* Extended Sections (Satisfaction, Condition Change, Service Change) */}
+        {showExtendedSections && (
+          <>
+            {record.satisfaction && (
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h6" gutterBottom>
+                      満足度
+                    </Typography>
+                    <Typography variant="body1" fontWeight={500}>
+                      {record.satisfaction}
+                    </Typography>
+                    {record.satisfactionReason && (
+                      <Typography variant="body2" color="text.secondary" mt={1}>
+                        {record.satisfactionReason}
+                      </Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+
+            {record.conditionChange && (
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h6" gutterBottom>
+                      状態の変化
+                    </Typography>
+                    <Typography variant="body1" fontWeight={500}>
+                      {record.conditionChange}
+                    </Typography>
+                    {record.conditionChangeDetail && (
+                      <Typography variant="body2" color="text.secondary" mt={1}>
+                        {record.conditionChangeDetail}
+                      </Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+
+            {record.serviceChangeNeeded && (
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Card>
+                  <CardContent>
+                    <Typography variant="h6" gutterBottom>
+                      サービス変更の必要性
+                    </Typography>
+                    <Typography variant="body1" fontWeight={500}>
+                      {record.serviceChangeNeeded}
+                    </Typography>
+                    {record.serviceChangeDetail && (
+                      <Typography variant="body2" color="text.secondary" mt={1}>
+                        {record.serviceChangeDetail}
+                      </Typography>
+                    )}
+                  </CardContent>
+                </Card>
+              </Grid>
+            )}
+          </>
+        )}
+
+        {/* Metadata */}
+        <Grid size={12}>
+          <Box display="flex" justifyContent="flex-end" gap={3}>
+            <Typography variant="caption" color="text.secondary">
+              作成: {new Date(record.createdAt).toLocaleString('ja-JP')}
+            </Typography>
+            {record.updatedAt !== record.createdAt && (
+              <Typography variant="caption" color="text.secondary">
+                更新: {new Date(record.updatedAt).toLocaleString('ja-JP')}
+              </Typography>
+            )}
+          </Box>
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/web/src/components/records/index.ts
+++ b/web/src/components/records/index.ts
@@ -1,0 +1,2 @@
+export { RecordDetailView } from './RecordDetailView';
+export type { RecordDetailViewProps, VisitRecordForDetail } from './RecordDetailView';

--- a/web/src/utils/formatters.ts
+++ b/web/src/utils/formatters.ts
@@ -1,0 +1,143 @@
+/**
+ * 共通フォーマットユーティリティ
+ * 本番/デモで共通使用
+ */
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+
+/**
+ * 日付フォーマット（曜日付き）
+ * @example "2026/01/10 (金)"
+ */
+export function formatDateWithWeekday(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '-';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const weekday = WEEKDAYS[date.getDay()];
+
+  return `${year}/${month}/${day} (${weekday})`;
+}
+
+/**
+ * 日付フォーマット（曜日なし）
+ * @example "2026/01/10"
+ */
+export function formatDateSlash(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '-';
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}/${month}/${day}`;
+}
+
+/**
+ * 日付フォーマット（日本語・曜日付き）
+ * @example "2026年1月10日 (金)"
+ */
+export function formatDateJapaneseWithWeekday(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '-';
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekday = WEEKDAYS[date.getDay()];
+
+  return `${year}年${month}月${day}日 (${weekday})`;
+}
+
+/**
+ * 日付フォーマット（日本語・曜日なし）
+ * @example "2026年1月10日"
+ */
+export function formatDateJapanese(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '-';
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+
+  return `${year}年${month}月${day}日`;
+}
+
+/**
+ * 日付フォーマット（短縮・曜日付き）
+ * @example "1/10 (金)"
+ */
+export function formatDateShortWithWeekday(dateStr: string | null | undefined): string {
+  if (!dateStr) return '-';
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return '-';
+
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const weekday = WEEKDAYS[date.getDay()];
+
+  return `${month}/${day} (${weekday})`;
+}
+
+/**
+ * 時間範囲フォーマット
+ * @example "09:00-10:30"
+ */
+export function formatTimeRange(startTime: string, endTime: string): string {
+  const start = startTime.slice(0, 5);
+  const end = endTime.slice(0, 5);
+  return `${start}-${end}`;
+}
+
+/**
+ * 時間フォーマット（秒を除去）
+ * @example "09:00"
+ */
+export function formatTime(time: string | null | undefined): string {
+  if (!time) return '-';
+  return time.slice(0, 5);
+}
+
+/**
+ * 住所を結合
+ * @example "東京都 新宿区"
+ */
+export function formatAddress(
+  prefecture: string | null | undefined,
+  city: string | null | undefined
+): string {
+  const parts = [prefecture, city].filter(Boolean);
+  return parts.join(' ') || '-';
+}
+
+/**
+ * テキストを指定文字数で切り詰め
+ * @example "長いテキスト..."
+ */
+export function truncateText(
+  text: string | null | undefined,
+  maxLength: number = 50
+): string {
+  if (!text) return '';
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength) + '...';
+}
+
+/**
+ * API用の日付フォーマット
+ * @example "2026-01-10"
+ */
+export function formatDateForApi(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './formatters';


### PR DESCRIPTION
## Summary

- **共通ユーティリティ関数の抽出**: `formatters.ts`に日付・時間・住所フォーマット関数を集約
- **RecordDetailView共通化**: 本番/デモの記録詳細ページで使用する共通コンポーネント作成
- **ClientDetailView共通化**: 本番/デモの利用者詳細ページで使用する共通コンポーネント作成
- **コード重複削減**: 約1300行のコード削減

## Test plan

- [ ] 本番環境で記録詳細ページが正常に表示される
- [ ] デモ環境で記録詳細ページが正常に表示される
- [ ] 本番環境で利用者詳細ページが正常に表示される
- [ ] デモ環境で利用者詳細ページが正常に表示される
- [ ] 各ページの「一覧に戻る」ボタンが正しいURLに遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)