### PR TITLE
Fix demo/production UI consistency: add dashboard links

### DIFF
--- a/web/src/app/demo/schedule/page.tsx
+++ b/web/src/app/demo/schedule/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { Box, CircularProgress, Alert, Typography } from '@mui/material';
+import { Box, CircularProgress, Alert } from '@mui/material';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, addDays } from 'date-fns';
 import { useDemoContext } from '@/contexts/DemoContext';
 import { dataConnect } from '@/lib/firebase';
@@ -185,12 +185,7 @@ export default function DemoSchedulePage() {
   }
 
   return (
-    <Box>
-      <Typography variant="h5" sx={{ mb: 3 }}>
-        スケジュール
-      </Typography>
-
-      <ScheduleCalendarView
+    <ScheduleCalendarView
         schedules={schedulesForCalendar}
         clients={clientOptions}
         staffList={staffOptions}
@@ -202,7 +197,6 @@ export default function DemoSchedulePage() {
         apiHandlers={apiHandlers}
         onRefetch={fetchSchedules}
         onDateRangeChange={handleDateRangeChange}
-      />
-    </Box>
+    />
   );
 }

--- a/web/src/components/layout/DemoSidebar.tsx
+++ b/web/src/components/layout/DemoSidebar.tsx
@@ -17,6 +17,7 @@ import {
   Chip,
 } from '@mui/material';
 import {
+  Dashboard as DashboardIcon,
   EditNote as RecordIcon,
   History as HistoryIcon,
   CalendarMonth as ScheduleIcon,
@@ -29,6 +30,7 @@ import {
 const DRAWER_WIDTH = 240;
 
 const menuItems = [
+  { text: 'ダッシュボード', icon: <DashboardIcon />, href: '/demo' },
   { text: '記録入力', icon: <RecordIcon />, href: '/demo/records/new' },
   { text: '履歴一覧', icon: <HistoryIcon />, href: '/demo/records' },
   { text: 'スケジュール', icon: <ScheduleIcon />, href: '/demo/schedule' },

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Divider,
 } from '@mui/material';
 import {
+  Dashboard as DashboardIcon,
   EditNote as RecordIcon,
   History as HistoryIcon,
   CalendarMonth as ScheduleIcon,
@@ -29,6 +30,7 @@ import {
 const DRAWER_WIDTH = 240;
 
 const menuItems = [
+  { text: 'ダッシュボード', icon: <DashboardIcon />, href: '/' },
   { text: '記録入力', icon: <RecordIcon />, href: '/records/new' },
   { text: '履歴一覧', icon: <HistoryIcon />, href: '/records' },
   { text: 'スケジュール', icon: <ScheduleIcon />, href: '/schedule' },


### PR DESCRIPTION
## Summary
- デモと本番のサイドバーに「ダッシュボード」リンクを追加
- デモスケジュールページから冗長なTypographyタイトルを削除
- デモと本番のUI構造を統一

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `DemoSidebar.tsx` | ダッシュボードリンク追加 (`/demo`) |
| `Sidebar.tsx` | ダッシュボードリンク追加 (`/`) |
| `demo/schedule/page.tsx` | Typographyタイトル削除 |

## Test plan
- [x] ビルド確認 (`npm run build`)
- [ ] デモ版ダッシュボードリンク動作確認
- [ ] 本番版ダッシュボードリンク動作確認
- [ ] デモ版スケジュールページカレンダー表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)