### PR TITLE
Fix FullCalendar display with minimum height

### DIFF
--- a/web/src/components/schedule/ScheduleCalendarView.tsx
+++ b/web/src/components/schedule/ScheduleCalendarView.tsx
@@ -575,7 +575,7 @@ export function ScheduleCalendarView({
           },
         }}
       >
-        <CardContent>
+        <CardContent sx={{ minHeight: 600 }}>
           <FullCalendar
             plugins={[dayGridPlugin, timeGridPlugin, interactionPlugin]}
             initialView="timeGridWeek"
@@ -608,8 +608,8 @@ export function ScheduleCalendarView({
             allDaySlot={false}
             weekends={true}
             nowIndicator={true}
-            height="auto"
-            aspectRatio={1.8}
+            height={600}
+            contentHeight="auto"
             firstDay={1}
             eventTimeFormat={{
               hour: '2-digit',


### PR DESCRIPTION
## Summary
カレンダーが表示されない問題を修正

## Changes
- `CardContent` に `minHeight: 600` を追加してコンテナが確実に表示されるように
- FullCalendar の `height` を "auto" から `600` に変更して一貫したレンダリングを実現
- `contentHeight="auto"` を使用してコンテンツサイズを適切に調整

## Root Cause
FullCalendar が `height="auto"` の場合、コンテナの高さが0になることがある問題

## Test plan
- [x] ビルド確認 (`npm run build`)
- [ ] 本番版スケジュールページでカレンダー表示確認
- [ ] デモ版スケジュールページでカレンダー表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)