### PR TITLE
Add Google Calendar-style views for schedule

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -9,3 +9,151 @@ html {
 .fc {
   font-family: inherit;
 }
+
+/* Google Calendar風スタイリング */
+
+/* 月ビュー - 今日のセルハイライト */
+.fc .fc-day-today {
+  background-color: rgba(33, 150, 243, 0.08) !important;
+}
+
+/* 月ビュー - 今日の日付番号 */
+.fc .fc-daygrid-day-number {
+  padding: 4px 8px;
+}
+
+.fc .fc-day-today .fc-daygrid-day-number {
+  background-color: #1976d2;
+  color: white;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 月ビュー - セルホバーエフェクト */
+.fc .fc-daygrid-day:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+/* 月ビュー - 週末の背景 */
+.fc .fc-day-sat,
+.fc .fc-day-sun {
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+/* +N件リンクスタイル */
+.fc .fc-daygrid-more-link {
+  color: #1976d2;
+  font-weight: 500;
+  font-size: 0.75rem;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.fc .fc-daygrid-more-link:hover {
+  background-color: rgba(25, 118, 210, 0.08);
+  text-decoration: none;
+}
+
+/* 月ビュー - イベントスタイル */
+.fc .fc-daygrid-event {
+  border-radius: 4px;
+  padding: 1px 4px;
+  font-size: 0.75rem;
+  margin: 1px 2px;
+}
+
+/* 月ビュー - イベントホバー */
+.fc .fc-daygrid-event:hover {
+  filter: brightness(0.95);
+}
+
+/* 週/日ビュー - タイムグリッドのイベント */
+.fc .fc-timegrid-event {
+  border-radius: 4px;
+  border-width: 0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+/* ヘッダーツールバーのスタイル調整 */
+.fc .fc-toolbar-title {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+/* ビュー切り替えボタン */
+.fc .fc-button {
+  border-radius: 4px;
+  text-transform: none;
+  font-weight: 500;
+  padding: 6px 12px;
+}
+
+.fc .fc-button-primary {
+  background-color: transparent;
+  border-color: #dadce0;
+  color: #3c4043;
+}
+
+.fc .fc-button-primary:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: #dadce0;
+  color: #3c4043;
+}
+
+.fc .fc-button-primary:not(:disabled).fc-button-active {
+  background-color: #e8f0fe;
+  border-color: #1976d2;
+  color: #1976d2;
+}
+
+/* 今日ボタン */
+.fc .fc-today-button {
+  background-color: transparent;
+  border: 1px solid #dadce0;
+  color: #3c4043;
+}
+
+.fc .fc-today-button:hover:not(:disabled) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+.fc .fc-today-button:disabled {
+  opacity: 0.5;
+}
+
+/* ナビゲーション矢印ボタン */
+.fc .fc-prev-button,
+.fc .fc-next-button {
+  background-color: transparent;
+  border: none;
+  color: #5f6368;
+  padding: 6px;
+}
+
+.fc .fc-prev-button:hover,
+.fc .fc-next-button:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 50%;
+}
+
+/* ポップオーバー（+N件クリック時） */
+.fc .fc-popover {
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border: none;
+}
+
+.fc .fc-popover-header {
+  background-color: #f1f3f4;
+  border-radius: 8px 8px 0 0;
+  padding: 8px 12px;
+  font-weight: 500;
+}
+
+.fc .fc-popover-body {
+  padding: 8px;
+}

--- a/web/src/components/schedule/ScheduleCalendarView.tsx
+++ b/web/src/components/schedule/ScheduleCalendarView.tsx
@@ -621,8 +621,53 @@ export function ScheduleCalendarView({
               minute: '2-digit',
               hour12: false,
             }}
+            dayMaxEvents={3}
+            moreLinkClick="popover"
+            moreLinkText={(num) => `+${num}件`}
+            views={{
+              timeGridDay: {
+                dayHeaderFormat: { weekday: 'long', month: 'numeric', day: 'numeric' }
+              }
+            }}
             eventContent={(arg: EventContentArg) => {
               const isRecurring = arg.event.extendedProps.isRecurring;
+              const viewType = arg.view.type;
+              const isMonthView = viewType === 'dayGridMonth';
+
+              // Month view: compact display
+              if (isMonthView) {
+                const clientName = arg.event.title.split('(')[0].trim();
+                return (
+                  <Box sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 0.5,
+                    overflow: 'hidden',
+                    width: '100%',
+                    px: 0.5,
+                    py: 0.25,
+                  }}>
+                    {isRecurring && (
+                      <RepeatIcon sx={{ fontSize: 12, flexShrink: 0 }} />
+                    )}
+                    <Typography
+                      variant="caption"
+                      component="span"
+                      sx={{
+                        fontSize: '0.7rem',
+                        fontWeight: 500,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {arg.timeText} {clientName}
+                    </Typography>
+                  </Box>
+                );
+              }
+
+              // Week/Day view: detailed display
               const duration = arg.event.end && arg.event.start
                 ? (arg.event.end.getTime() - arg.event.start.getTime()) / (1000 * 60)
                 : 60;


### PR DESCRIPTION
## Summary
- 月ビューで「+N件」表示機能を追加（3件以上の予定がある日はポップオーバーで表示）
- ビュータイプに応じたイベント表示の最適化（月ビューはコンパクト表示）
- Googleカレンダー風のCSSスタイリングを追加
  - 今日の日付を青い丸でハイライト
  - セルホバーエフェクト
  - 週末の背景スタイリング
  - ボタン・ツールバーのスタイリング
  - +N件クリック時のポップオーバースタイリング
- 日ビューのヘッダーフォーマット改善

## Test plan
- [ ] `/schedule` または `/demo/schedule` にアクセス
- [ ] 月ビューに切り替え
  - [ ] 3件以上の予定がある日で「+N件」表示を確認
  - [ ] 「+N件」クリックでポップオーバー表示を確認
  - [ ] 今日の日付が青い丸でハイライトされていることを確認
  - [ ] セルホバーで背景色が変わることを確認
- [ ] 週/日ビューの動作に変更がないことを確認
- [ ] デモページと本番ページの両方で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)