### PR TITLE
Fix calendar view switching not working

### DIFF
--- a/web/e2e/schedule.spec.ts
+++ b/web/e2e/schedule.spec.ts
@@ -25,27 +25,31 @@ test.describe('Demo Schedule Page', () => {
     await expect(page.locator('.fc-timeGridWeek-button, .fc-dayGridMonth-button').first()).toBeVisible();
   });
 
-  test.skip('should be able to switch calendar views', async ({ page }) => {
+  test('should be able to switch calendar views', async ({ page }) => {
     // カレンダーが読み込まれるまで待機
     await expect(page.locator('.fc')).toBeVisible({ timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    // 初期表示は週ビュー
+    await expect(page.locator('.fc-timeGridWeek-view')).toBeVisible();
 
     // 月表示に切り替え
     const monthButton = page.locator('.fc-dayGridMonth-button');
-    if (await monthButton.isVisible()) {
-      await monthButton.click();
-      // 月表示のロード待機
-      await page.waitForTimeout(2000);
-      await expect(page.locator('.fc-daygrid-body')).toBeVisible({ timeout: 10000 });
-    }
+    await monthButton.click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-dayGridMonth-view')).toBeVisible({ timeout: 10000 });
 
-    // 週表示に切り替え
+    // 日表示に切り替え
+    const dayButton = page.locator('.fc-timeGridDay-button');
+    await dayButton.click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-timeGridDay-view')).toBeVisible({ timeout: 10000 });
+
+    // 週表示に戻す
     const weekButton = page.locator('.fc-timeGridWeek-button');
-    if (await weekButton.isVisible()) {
-      await weekButton.click();
-      // 週表示のロード待機
-      await page.waitForTimeout(2000);
-      await expect(page.locator('.fc-timegrid-body')).toBeVisible({ timeout: 10000 });
-    }
+    await weekButton.click();
+    await page.waitForTimeout(2000);
+    await expect(page.locator('.fc-timeGridWeek-view')).toBeVisible({ timeout: 10000 });
   });
 
   test.skip('should navigate to previous/next periods', async ({ page }) => {

--- a/web/src/app/demo/schedule/page.tsx
+++ b/web/src/app/demo/schedule/page.tsx
@@ -126,7 +126,10 @@ export default function DemoSchedulePage() {
     if (!facilityId) return;
 
     const loadSchedules = async () => {
-      setLoading(true);
+      // Only show loading on initial load, not on view changes
+      if (schedules.length === 0) {
+        setLoading(true);
+      }
       await fetchSchedules();
       setLoading(false);
     };
@@ -202,16 +205,18 @@ export default function DemoSchedulePage() {
     await fetchSchedules(true);
   }, [fetchSchedules]);
 
-  if (loading) {
+  // Show error if any
+  if (error) {
+    return <Alert severity="error">{error}</Alert>;
+  }
+
+  // Show loading overlay on initial load only
+  if (loading && schedules.length === 0) {
     return (
       <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
         <CircularProgress />
       </Box>
     );
-  }
-
-  if (error) {
-    return <Alert severity="error">{error}</Alert>;
   }
 
   return (

--- a/web/src/app/schedule/page.tsx
+++ b/web/src/app/schedule/page.tsx
@@ -139,7 +139,10 @@ export default function SchedulePage() {
     if (!facilityId) return;
 
     const loadSchedules = async () => {
-      setLoading(true);
+      // Only show loading on initial load, not on view changes
+      if (schedules.length === 0) {
+        setLoading(true);
+      }
       await fetchSchedules();
       setLoading(false);
     };
@@ -209,7 +212,8 @@ export default function SchedulePage() {
     }));
   }, [serviceTypes]);
 
-  if (staffLoading || loading) {
+  // Show loading only on initial load (before schedules are loaded)
+  if (staffLoading || (loading && schedules.length === 0)) {
     return (
       <MainLayout title="スケジュール" showBackButton backHref="/">
         <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">


### PR DESCRIPTION
## Summary
- カレンダーのビュー切り替え（月/週/日）が動作しない問題を修正
- 原因: ビュー変更時に`setLoading(true)`が呼ばれ、コンポーネントが再マウント
- FullCalendarが`initialView="timeGridWeek"`で再初期化されていた

## Changes
- 初回ロード時のみローディング表示（`schedules.length === 0`の場合のみ）
- ビュー変更中もカレンダーを表示し続ける
- E2Eテストを有効化（`test.skip` → `test`）

## Test plan
- [x] `/demo/schedule` にアクセス
- [x] 「月」ボタンクリック → 月ビューに切り替わる
- [x] 「日」ボタンクリック → 日ビューに切り替わる
- [x] 「週」ボタンクリック → 週ビューに切り替わる
- [x] E2Eテスト成功（6/7、1つはスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)