### PR TITLE
Add responsive layout for mobile devices

### DIFF
--- a/web/src/components/layout/DemoHeader.tsx
+++ b/web/src/components/layout/DemoHeader.tsx
@@ -8,26 +8,45 @@ import {
   Box,
   Avatar,
   Chip,
+  IconButton,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
+import { Menu as MenuIcon } from '@mui/icons-material';
 import { DRAWER_WIDTH } from './DemoSidebar';
 
 interface DemoHeaderProps {
   title?: string;
+  onMenuClick?: () => void;
 }
 
-export default function DemoHeader({ title = '訪問介護記録管理' }: DemoHeaderProps) {
+export default function DemoHeader({ title = '訪問介護記録管理', onMenuClick }: DemoHeaderProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
   return (
     <AppBar
       position="fixed"
       sx={{
-        width: `calc(100% - ${DRAWER_WIDTH}px)`,
-        ml: `${DRAWER_WIDTH}px`,
+        width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
+        ml: isMobile ? 0 : `${DRAWER_WIDTH}px`,
         bgcolor: 'background.paper',
         color: 'text.primary',
         boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
       }}
     >
       <Toolbar>
+        {isMobile && (
+          <IconButton
+            color="inherit"
+            aria-label="メニューを開く"
+            edge="start"
+            onClick={onMenuClick}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
           <Typography variant="h6" noWrap component="div">
             {title}
@@ -40,9 +59,11 @@ export default function DemoHeader({ title = '訪問介護記録管理' }: DemoH
           >
             D
           </Avatar>
-          <Typography variant="body2" color="text.secondary">
-            デモユーザー
-          </Typography>
+          {!isMobile && (
+            <Typography variant="body2" color="text.secondary">
+              デモユーザー
+            </Typography>
+          )}
         </Box>
       </Toolbar>
     </AppBar>

--- a/web/src/components/layout/DemoLayout.tsx
+++ b/web/src/components/layout/DemoLayout.tsx
@@ -14,6 +14,8 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Refresh as RefreshIcon,
@@ -29,6 +31,9 @@ interface DemoLayoutProps {
 }
 
 export default function DemoLayout({ children, title }: DemoLayoutProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileOpen, setMobileOpen] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: 'success' | 'error' }>({
@@ -36,6 +41,14 @@ export default function DemoLayout({ children, title }: DemoLayoutProps) {
     message: '',
     severity: 'success',
   });
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const handleDrawerClose = () => {
+    setMobileOpen(false);
+  };
 
   const handleResetClick = () => {
     setConfirmOpen(true);
@@ -91,14 +104,14 @@ export default function DemoLayout({ children, title }: DemoLayoutProps) {
   return (
     <DemoProvider>
       <Box sx={{ display: 'flex', minHeight: '100vh' }}>
-        <DemoSidebar />
-        <DemoHeader title={title} />
+        <DemoSidebar open={mobileOpen} onClose={handleDrawerClose} />
+        <DemoHeader title={title} onMenuClick={handleDrawerToggle} />
         <Box
           component="main"
           sx={{
             flexGrow: 1,
-            p: 3,
-            width: `calc(100% - ${DRAWER_WIDTH}px)`,
+            p: { xs: 2, sm: 3 },
+            width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
             bgcolor: 'background.default',
           }}
         >

--- a/web/src/components/layout/DemoSidebar.tsx
+++ b/web/src/components/layout/DemoSidebar.tsx
@@ -15,6 +15,8 @@ import {
   Typography,
   Divider,
   Chip,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Dashboard as DashboardIcon,
@@ -43,21 +45,18 @@ const bottomItems = [
   { text: '本番サイトへ', icon: <HomeIcon />, href: '/' },
 ];
 
-export default function DemoSidebar() {
-  const pathname = usePathname();
+interface DemoSidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
 
-  return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: DRAWER_WIDTH,
-        flexShrink: 0,
-        '& .MuiDrawer-paper': {
-          width: DRAWER_WIDTH,
-          boxSizing: 'border-box',
-        },
-      }}
-    >
+export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
+  const pathname = usePathname();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const drawerContent = (
+    <>
       <Toolbar>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
           <Typography variant="h6" noWrap component="div" sx={{ fontWeight: 600 }}>
@@ -75,6 +74,7 @@ export default function DemoSidebar() {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href || pathname?.startsWith(item.href + '/')}
+                onClick={isMobile ? onClose : undefined}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -89,6 +89,7 @@ export default function DemoSidebar() {
               <ListItemButton
                 component={Link}
                 href={item.href}
+                onClick={isMobile ? onClose : undefined}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -97,6 +98,45 @@ export default function DemoSidebar() {
           ))}
         </List>
       </Box>
+    </>
+  );
+
+  // モバイル: temporary drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{
+          keepMounted: true, // パフォーマンス向上
+        }}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    );
+  }
+
+  // デスクトップ: permanent drawer
+  return (
+    <Drawer
+      variant="permanent"
+      sx={{
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: DRAWER_WIDTH,
+          boxSizing: 'border-box',
+        },
+      }}
+    >
+      {drawerContent}
     </Drawer>
   );
 }

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -11,8 +11,10 @@ import {
   Menu,
   MenuItem,
   Divider,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { ArrowBack as ArrowBackIcon, Menu as MenuIcon } from '@mui/icons-material';
 import { useRouter } from 'next/navigation';
 import { DRAWER_WIDTH } from './Sidebar';
 import { useAuth } from '@/contexts/AuthContext';
@@ -21,11 +23,14 @@ interface HeaderProps {
   title?: string;
   showBackButton?: boolean;
   backHref?: string;
+  onMenuClick?: () => void;
 }
 
-export default function Header({ title = '訪問介護記録管理', showBackButton = false, backHref }: HeaderProps) {
+export default function Header({ title = '訪問介護記録管理', showBackButton = false, backHref, onMenuClick }: HeaderProps) {
   const router = useRouter();
   const { user, signOut } = useAuth();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -45,17 +50,28 @@ export default function Header({ title = '訪問介護記録管理', showBackBut
     <AppBar
       position="fixed"
       sx={{
-        width: `calc(100% - ${DRAWER_WIDTH}px)`,
-        ml: `${DRAWER_WIDTH}px`,
+        width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
+        ml: isMobile ? 0 : `${DRAWER_WIDTH}px`,
         bgcolor: 'background.paper',
         color: 'text.primary',
         boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
       }}
     >
       <Toolbar>
+        {isMobile && (
+          <IconButton
+            color="inherit"
+            aria-label="メニューを開く"
+            edge="start"
+            onClick={onMenuClick}
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+        )}
         {showBackButton && (
           <IconButton
-            edge="start"
+            edge={isMobile ? false : 'start'}
             color="inherit"
             aria-label="戻る"
             onClick={() => backHref ? router.push(backHref) : router.back()}

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import * as React from 'react';
-import { Box, Toolbar } from '@mui/material';
+import { useState } from 'react';
+import { Box, Toolbar, useMediaQuery, useTheme } from '@mui/material';
 import Sidebar, { DRAWER_WIDTH } from './Sidebar';
 import Header from './Header';
 import AuthGuard from '../AuthGuard';
@@ -14,17 +15,34 @@ interface MainLayoutProps {
 }
 
 export default function MainLayout({ children, title, showBackButton, backHref }: MainLayoutProps) {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
+  };
+
+  const handleDrawerClose = () => {
+    setMobileOpen(false);
+  };
+
   return (
     <AuthGuard>
       <Box sx={{ display: 'flex', minHeight: '100vh' }}>
-        <Sidebar />
-        <Header title={title} showBackButton={showBackButton} backHref={backHref} />
+        <Sidebar open={mobileOpen} onClose={handleDrawerClose} />
+        <Header
+          title={title}
+          showBackButton={showBackButton}
+          backHref={backHref}
+          onMenuClick={handleDrawerToggle}
+        />
         <Box
           component="main"
           sx={{
             flexGrow: 1,
-            p: 3,
-            width: `calc(100% - ${DRAWER_WIDTH}px)`,
+            p: { xs: 2, sm: 3 },
+            width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
             bgcolor: 'background.default',
           }}
         >

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -14,6 +14,8 @@ import {
   Box,
   Typography,
   Divider,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Dashboard as DashboardIcon,
@@ -44,21 +46,18 @@ const settingsItems = [
   { text: '設定', icon: <SettingsIcon />, href: '/settings' },
 ];
 
-export default function Sidebar() {
-  const pathname = usePathname();
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
 
-  return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: DRAWER_WIDTH,
-        flexShrink: 0,
-        '& .MuiDrawer-paper': {
-          width: DRAWER_WIDTH,
-          boxSizing: 'border-box',
-        },
-      }}
-    >
+export default function Sidebar({ open, onClose }: SidebarProps) {
+  const pathname = usePathname();
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const drawerContent = (
+    <>
       <Toolbar>
         <Typography variant="h6" noWrap component="div" sx={{ fontWeight: 600 }}>
           訪問介護記録
@@ -73,6 +72,7 @@ export default function Sidebar() {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href || pathname?.startsWith(item.href + '/')}
+                onClick={isMobile ? onClose : undefined}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -88,6 +88,7 @@ export default function Sidebar() {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href}
+                onClick={isMobile ? onClose : undefined}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -96,6 +97,45 @@ export default function Sidebar() {
           ))}
         </List>
       </Box>
+    </>
+  );
+
+  // モバイル: temporary drawer
+  if (isMobile) {
+    return (
+      <Drawer
+        variant="temporary"
+        open={open}
+        onClose={onClose}
+        ModalProps={{
+          keepMounted: true, // パフォーマンス向上
+        }}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    );
+  }
+
+  // デスクトップ: permanent drawer
+  return (
+    <Drawer
+      variant="permanent"
+      sx={{
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        '& .MuiDrawer-paper': {
+          width: DRAWER_WIDTH,
+          boxSizing: 'border-box',
+        },
+      }}
+    >
+      {drawerContent}
     </Drawer>
   );
 }


### PR DESCRIPTION
## Summary
- モバイル画面（900px以下）でサイドバーを非表示にしハンバーガーメニューで開閉
- デスクトップ画面ではサイドバーを常時表示（従来通り）
- デモ環境・本番環境の両方に対応

## Test plan
- [ ] モバイル画面（900px以下）でハンバーガーメニューが表示されることを確認
- [ ] ハンバーガーメニューをタップしてサイドバーが開閉することを確認
- [ ] サイドバーのメニュー項目をタップすると自動で閉じることを確認
- [ ] デスクトップ画面（900px超）でサイドバーが常時表示されることを確認
- [ ] デモ環境（/demo）で同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)