### PR TITLE
Fix responsive layout using CSS media queries

### DIFF
--- a/web/src/components/layout/DemoHeader.tsx
+++ b/web/src/components/layout/DemoHeader.tsx
@@ -9,8 +9,6 @@ import {
   Avatar,
   Chip,
   IconButton,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import { Menu as MenuIcon } from '@mui/icons-material';
 import { DRAWER_WIDTH } from './DemoSidebar';
@@ -21,32 +19,27 @@ interface DemoHeaderProps {
 }
 
 export default function DemoHeader({ title = '訪問介護記録管理', onMenuClick }: DemoHeaderProps) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
   return (
     <AppBar
       position="fixed"
       sx={{
-        width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
-        ml: isMobile ? 0 : `${DRAWER_WIDTH}px`,
+        width: { xs: '100%', md: `calc(100% - ${DRAWER_WIDTH}px)` },
+        ml: { xs: 0, md: `${DRAWER_WIDTH}px` },
         bgcolor: 'background.paper',
         color: 'text.primary',
         boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
       }}
     >
       <Toolbar>
-        {isMobile && (
-          <IconButton
-            color="inherit"
-            aria-label="メニューを開く"
-            edge="start"
-            onClick={onMenuClick}
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-        )}
+        <IconButton
+          color="inherit"
+          aria-label="メニューを開く"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2, display: { xs: 'flex', md: 'none' } }}
+        >
+          <MenuIcon />
+        </IconButton>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexGrow: 1 }}>
           <Typography variant="h6" noWrap component="div">
             {title}
@@ -59,11 +52,13 @@ export default function DemoHeader({ title = '訪問介護記録管理', onMenuC
           >
             D
           </Avatar>
-          {!isMobile && (
-            <Typography variant="body2" color="text.secondary">
-              デモユーザー
-            </Typography>
-          )}
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ display: { xs: 'none', md: 'block' } }}
+          >
+            デモユーザー
+          </Typography>
         </Box>
       </Toolbar>
     </AppBar>

--- a/web/src/components/layout/DemoLayout.tsx
+++ b/web/src/components/layout/DemoLayout.tsx
@@ -14,8 +14,6 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import {
   Refresh as RefreshIcon,
@@ -31,8 +29,6 @@ interface DemoLayoutProps {
 }
 
 export default function DemoLayout({ children, title }: DemoLayoutProps) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileOpen, setMobileOpen] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -111,7 +107,7 @@ export default function DemoLayout({ children, title }: DemoLayoutProps) {
           sx={{
             flexGrow: 1,
             p: { xs: 2, sm: 3 },
-            width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
+            width: { xs: '100%', md: `calc(100% - ${DRAWER_WIDTH}px)` },
             bgcolor: 'background.default',
           }}
         >

--- a/web/src/components/layout/DemoSidebar.tsx
+++ b/web/src/components/layout/DemoSidebar.tsx
@@ -15,8 +15,6 @@ import {
   Typography,
   Divider,
   Chip,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import {
   Dashboard as DashboardIcon,
@@ -52,8 +50,6 @@ interface DemoSidebarProps {
 
 export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
   const pathname = usePathname();
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   const drawerContent = (
     <>
@@ -74,7 +70,7 @@ export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href || pathname?.startsWith(item.href + '/')}
-                onClick={isMobile ? onClose : undefined}
+                onClick={onClose}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -89,7 +85,7 @@ export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
               <ListItemButton
                 component={Link}
                 href={item.href}
-                onClick={isMobile ? onClose : undefined}
+                onClick={onClose}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -101,17 +97,18 @@ export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
     </>
   );
 
-  // モバイル: temporary drawer
-  if (isMobile) {
-    return (
+  return (
+    <>
+      {/* モバイル: temporary drawer */}
       <Drawer
         variant="temporary"
         open={open}
         onClose={onClose}
         ModalProps={{
-          keepMounted: true, // パフォーマンス向上
+          keepMounted: true,
         }}
         sx={{
+          display: { xs: 'block', md: 'none' },
           '& .MuiDrawer-paper': {
             width: DRAWER_WIDTH,
             boxSizing: 'border-box',
@@ -120,24 +117,23 @@ export default function DemoSidebar({ open, onClose }: DemoSidebarProps) {
       >
         {drawerContent}
       </Drawer>
-    );
-  }
 
-  // デスクトップ: permanent drawer
-  return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: DRAWER_WIDTH,
-        flexShrink: 0,
-        '& .MuiDrawer-paper': {
+      {/* デスクトップ: permanent drawer */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', md: 'block' },
           width: DRAWER_WIDTH,
-          boxSizing: 'border-box',
-        },
-      }}
-    >
-      {drawerContent}
-    </Drawer>
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    </>
   );
 }
 

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -11,8 +11,6 @@ import {
   Menu,
   MenuItem,
   Divider,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import { ArrowBack as ArrowBackIcon, Menu as MenuIcon } from '@mui/icons-material';
 import { useRouter } from 'next/navigation';
@@ -29,8 +27,6 @@ interface HeaderProps {
 export default function Header({ title = '訪問介護記録管理', showBackButton = false, backHref, onMenuClick }: HeaderProps) {
   const router = useRouter();
   const { user, signOut } = useAuth();
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -50,28 +46,25 @@ export default function Header({ title = '訪問介護記録管理', showBackBut
     <AppBar
       position="fixed"
       sx={{
-        width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
-        ml: isMobile ? 0 : `${DRAWER_WIDTH}px`,
+        width: { xs: '100%', md: `calc(100% - ${DRAWER_WIDTH}px)` },
+        ml: { xs: 0, md: `${DRAWER_WIDTH}px` },
         bgcolor: 'background.paper',
         color: 'text.primary',
         boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
       }}
     >
       <Toolbar>
-        {isMobile && (
-          <IconButton
-            color="inherit"
-            aria-label="メニューを開く"
-            edge="start"
-            onClick={onMenuClick}
-            sx={{ mr: 2 }}
-          >
-            <MenuIcon />
-          </IconButton>
-        )}
+        <IconButton
+          color="inherit"
+          aria-label="メニューを開く"
+          edge="start"
+          onClick={onMenuClick}
+          sx={{ mr: 2, display: { xs: 'flex', md: 'none' } }}
+        >
+          <MenuIcon />
+        </IconButton>
         {showBackButton && (
           <IconButton
-            edge={isMobile ? false : 'start'}
             color="inherit"
             aria-label="戻る"
             onClick={() => backHref ? router.push(backHref) : router.back()}

--- a/web/src/components/layout/MainLayout.tsx
+++ b/web/src/components/layout/MainLayout.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { useState } from 'react';
-import { Box, Toolbar, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Toolbar } from '@mui/material';
 import Sidebar, { DRAWER_WIDTH } from './Sidebar';
 import Header from './Header';
 import AuthGuard from '../AuthGuard';
@@ -15,8 +15,6 @@ interface MainLayoutProps {
 }
 
 export default function MainLayout({ children, title, showBackButton, backHref }: MainLayoutProps) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const handleDrawerToggle = () => {
@@ -42,7 +40,7 @@ export default function MainLayout({ children, title, showBackButton, backHref }
           sx={{
             flexGrow: 1,
             p: { xs: 2, sm: 3 },
-            width: isMobile ? '100%' : `calc(100% - ${DRAWER_WIDTH}px)`,
+            width: { xs: '100%', md: `calc(100% - ${DRAWER_WIDTH}px)` },
             bgcolor: 'background.default',
           }}
         >

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -14,8 +14,6 @@ import {
   Box,
   Typography,
   Divider,
-  useMediaQuery,
-  useTheme,
 } from '@mui/material';
 import {
   Dashboard as DashboardIcon,
@@ -53,8 +51,6 @@ interface SidebarProps {
 
 export default function Sidebar({ open, onClose }: SidebarProps) {
   const pathname = usePathname();
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   const drawerContent = (
     <>
@@ -72,7 +68,7 @@ export default function Sidebar({ open, onClose }: SidebarProps) {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href || pathname?.startsWith(item.href + '/')}
-                onClick={isMobile ? onClose : undefined}
+                onClick={onClose}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -88,7 +84,7 @@ export default function Sidebar({ open, onClose }: SidebarProps) {
                 component={Link}
                 href={item.href}
                 selected={pathname === item.href}
-                onClick={isMobile ? onClose : undefined}
+                onClick={onClose}
               >
                 <ListItemIcon>{item.icon}</ListItemIcon>
                 <ListItemText primary={item.text} />
@@ -100,17 +96,18 @@ export default function Sidebar({ open, onClose }: SidebarProps) {
     </>
   );
 
-  // モバイル: temporary drawer
-  if (isMobile) {
-    return (
+  return (
+    <>
+      {/* モバイル: temporary drawer */}
       <Drawer
         variant="temporary"
         open={open}
         onClose={onClose}
         ModalProps={{
-          keepMounted: true, // パフォーマンス向上
+          keepMounted: true,
         }}
         sx={{
+          display: { xs: 'block', md: 'none' },
           '& .MuiDrawer-paper': {
             width: DRAWER_WIDTH,
             boxSizing: 'border-box',
@@ -119,24 +116,23 @@ export default function Sidebar({ open, onClose }: SidebarProps) {
       >
         {drawerContent}
       </Drawer>
-    );
-  }
 
-  // デスクトップ: permanent drawer
-  return (
-    <Drawer
-      variant="permanent"
-      sx={{
-        width: DRAWER_WIDTH,
-        flexShrink: 0,
-        '& .MuiDrawer-paper': {
+      {/* デスクトップ: permanent drawer */}
+      <Drawer
+        variant="permanent"
+        sx={{
+          display: { xs: 'none', md: 'block' },
           width: DRAWER_WIDTH,
-          boxSizing: 'border-box',
-        },
-      }}
-    >
-      {drawerContent}
-    </Drawer>
+          flexShrink: 0,
+          '& .MuiDrawer-paper': {
+            width: DRAWER_WIDTH,
+            boxSizing: 'border-box',
+          },
+        }}
+      >
+        {drawerContent}
+      </Drawer>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- `useMediaQuery`をCSSベースのメディアクエリに置き換え
- 静的エクスポートでSSR問題が発生していた（useMediaQueryがビルド時にfalseを返す）
- `sx={{ display: { xs: 'block', md: 'none' } }}`でCSSメディアクエリを使用

## Changes
- 両方のDrawer（temporary/permanent）をレンダリングし、CSSで表示切り替え
- Header/Layoutの幅もCSSブレークポイントで制御

## Test plan
- [ ] モバイル画面（900px以下）でサイドバーが非表示
- [ ] ハンバーガーメニューが表示される
- [ ] メニュータップでサイドバーが開く
- [ ] デスクトップ画面（900px超）でサイドバー常時表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)