### PR TITLE
Optimize calendar mobile display with responsive styles

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -42,3 +42,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+e2e-results/

--- a/web/e2e/schedule-mobile.spec.ts
+++ b/web/e2e/schedule-mobile.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+
+// モバイルビューポート設定（iPhone 14相当）
+test.use({
+  viewport: { width: 390, height: 844 },
+  isMobile: true,
+  hasTouch: true,
+});
+
+test.describe('Schedule Mobile View', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/demo/schedule');
+    // カレンダーが読み込まれるまで待機
+    await expect(page.locator('.fc')).toBeVisible({ timeout: 30000 });
+  });
+
+  test('should display calendar on mobile - week view', async ({ page }) => {
+    // スクリーンショットを撮影
+    await page.screenshot({ path: 'e2e-results/mobile-week-view.png', fullPage: true });
+
+    // ツールバーが見えることを確認
+    await expect(page.locator('.fc-toolbar')).toBeVisible();
+
+    // タイトルが見えることを確認
+    await expect(page.locator('.fc-toolbar-title')).toBeVisible();
+  });
+
+  test('should display calendar on mobile - day view', async ({ page }) => {
+    // 日表示に切り替え
+    const dayButton = page.locator('.fc-timeGridDay-button');
+    await dayButton.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({ path: 'e2e-results/mobile-day-view.png', fullPage: true });
+
+    await expect(page.locator('.fc-timeGridDay-view')).toBeVisible();
+  });
+
+  test('should display calendar on mobile - month view', async ({ page }) => {
+    // 月表示に切り替え
+    const monthButton = page.locator('.fc-dayGridMonth-button');
+    await monthButton.click();
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({ path: 'e2e-results/mobile-month-view.png', fullPage: true });
+
+    await expect(page.locator('.fc-dayGridMonth-view')).toBeVisible();
+  });
+
+  test('should open hamburger menu on mobile', async ({ page }) => {
+    // ハンバーガーメニューボタンをクリック
+    const menuButton = page.locator('button[aria-label="メニューを開く"]');
+    await expect(menuButton).toBeVisible();
+    await menuButton.click();
+
+    // サイドバーが開くことを確認（role="dialog"のtemporary drawer）
+    await expect(page.locator('[role="dialog"].MuiDrawer-paper')).toBeVisible();
+
+    await page.screenshot({ path: 'e2e-results/mobile-sidebar-open.png', fullPage: true });
+  });
+
+  test('should display events on mobile', async ({ page }) => {
+    // イベントが存在するか確認
+    const events = page.locator('.fc-event');
+    const eventCount = await events.count();
+    console.log(`Found ${eventCount} events on mobile view`);
+
+    if (eventCount > 0) {
+      await page.screenshot({ path: 'e2e-results/mobile-with-events.png', fullPage: true });
+    }
+  });
+});

--- a/web/src/components/layout/DemoLayout.tsx
+++ b/web/src/components/layout/DemoLayout.tsx
@@ -14,6 +14,9 @@ import {
   DialogContent,
   DialogContentText,
   DialogActions,
+  IconButton,
+  Tooltip,
+  Typography,
 } from '@mui/material';
 import {
   Refresh as RefreshIcon,
@@ -116,18 +119,30 @@ export default function DemoLayout({ children, title }: DemoLayoutProps) {
             severity="info"
             sx={{ mb: 2 }}
             action={
-              <Button
-                color="inherit"
-                size="small"
-                startIcon={resetting ? <CircularProgress size={16} color="inherit" /> : <RefreshIcon />}
-                onClick={handleResetClick}
-                disabled={resetting}
-              >
-                リセット
-              </Button>
+              <Tooltip title="データをリセット">
+                <IconButton
+                  color="inherit"
+                  size="small"
+                  onClick={handleResetClick}
+                  disabled={resetting}
+                >
+                  {resetting ? <CircularProgress size={18} color="inherit" /> : <RefreshIcon />}
+                </IconButton>
+              </Tooltip>
             }
           >
-            これはデモ環境です。サンプルデータを表示しています。自由に操作できます。
+            <Typography
+              variant="body2"
+              sx={{ display: { xs: 'none', sm: 'block' } }}
+            >
+              これはデモ環境です。サンプルデータを表示しています。自由に操作できます。
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{ display: { xs: 'block', sm: 'none' } }}
+            >
+              デモ環境です。自由に操作できます。
+            </Typography>
           </Alert>
           {children}
         </Box>

--- a/web/src/components/schedule/ScheduleCalendarView.tsx
+++ b/web/src/components/schedule/ScheduleCalendarView.tsx
@@ -515,8 +515,8 @@ export function ScheduleCalendarView({
     <Box>
       {/* Header */}
       <Card sx={{ mb: 2 }}>
-        <CardContent sx={{ py: 1.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <Box display="flex" gap={1} flexWrap="wrap">
+        <CardContent sx={{ py: 1.5, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 1 }}>
+          <Box display="flex" gap={0.5} flexWrap="wrap" sx={{ flex: 1, minWidth: 0 }}>
             {Object.entries(SERVICE_COLORS)
               .filter(([key]) => key !== 'default')
               .map(([category, color]) => (
@@ -524,16 +524,35 @@ export function ScheduleCalendarView({
                   key={category}
                   label={category}
                   size="small"
-                  sx={{ backgroundColor: color, color: 'white' }}
+                  sx={{
+                    backgroundColor: color,
+                    color: 'white',
+                    fontSize: { xs: '0.65rem', sm: '0.75rem' },
+                    height: { xs: 22, sm: 24 },
+                  }}
                 />
               ))}
           </Box>
+          {/* デスクトップ: テキスト付きボタン */}
           <Button
             variant="contained"
             startIcon={<AddIcon />}
             onClick={handleOpenNewDialog}
+            sx={{ display: { xs: 'none', sm: 'flex' }, whiteSpace: 'nowrap' }}
           >
             新規予定
+          </Button>
+          {/* モバイル: アイコンボタン */}
+          <Button
+            variant="contained"
+            onClick={handleOpenNewDialog}
+            sx={{
+              display: { xs: 'flex', sm: 'none' },
+              minWidth: 40,
+              px: 1,
+            }}
+          >
+            <AddIcon />
           </Button>
         </CardContent>
       </Card>
@@ -572,6 +591,49 @@ export function ScheduleCalendarView({
           },
           '& .fc-timegrid-now-indicator-arrow': {
             borderColor: '#EA4335',
+          },
+          // Mobile responsive styles
+          '@media (max-width: 600px)': {
+            // Toolbar layout
+            '& .fc-toolbar': {
+              flexDirection: 'column',
+              gap: '8px',
+            },
+            '& .fc-toolbar-chunk': {
+              display: 'flex',
+              justifyContent: 'center',
+            },
+            '& .fc-toolbar-title': {
+              fontSize: '1rem !important',
+            },
+            // View buttons
+            '& .fc-button': {
+              padding: '4px 8px',
+              fontSize: '0.75rem',
+            },
+            // Day headers
+            '& .fc-col-header-cell': {
+              fontSize: '0.65rem',
+            },
+            '& .fc-col-header-cell-cushion': {
+              padding: '2px',
+            },
+            // Time labels
+            '& .fc-timegrid-slot-label': {
+              fontSize: '0.65rem',
+            },
+            '& .fc-timegrid-axis-cushion': {
+              padding: '0 2px',
+            },
+            // Events
+            '& .fc-event': {
+              fontSize: '0.6rem',
+            },
+            // Month view day numbers
+            '& .fc-daygrid-day-number': {
+              fontSize: '0.75rem',
+              padding: '2px',
+            },
           },
         }}
       >


### PR DESCRIPTION
## Summary
- カレンダーのモバイル表示を最適化
- CSS media queriesでツールバーの縦積み、フォントサイズの調整
- ヘッダーボタン・Alertをアイコンのみに変更（モバイル時）
- モバイル用E2Eテストを追加

## Changes
- `ScheduleCalendarView.tsx`: モバイル向けCSSスタイル追加（ツールバー、ボタン、日付ヘッダー、時間ラベル、イベント）
- `DemoLayout.tsx`: Alert actionをIconButtonに変更、メッセージをモバイル用に短縮
- `schedule-mobile.spec.ts`: モバイルE2Eテスト追加（週/日/月表示、ハンバーガーメニュー、イベント表示）

## Test plan
- [x] E2Eテスト全5件パス
- [x] ビルド成功
- [ ] 実機でモバイル表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)